### PR TITLE
fix: include auth token in media playback and file download URLs

### DIFF
--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -15,7 +15,7 @@ import { useAuth } from '../../contexts/AuthContext';
  * @param {Function} props.onDelete - Handler for single event deletion
  */
 export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected, onToggleSelect, getMediaUrl, onDelete }) => {
-    const { user } = useAuth();
+    const { user, token } = useAuth();
     const [imgError, setImgError] = useState(false);
     const time = new Date(event.timestamp_start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     const date = new Date(event.timestamp_start).toLocaleDateString([], { month: 'short', day: 'numeric' });
@@ -75,7 +75,7 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
                 <div className="absolute top-1 right-1 flex flex-col gap-1 opacity-90 transition-opacity z-10">
                     {/* Download */}
                     <a
-                        href={`/api/events/${event.id}/download`}
+                        href={`/api/events/${event.id}/download${token ? `?token=${token}` : ""}`}
                         download
                         onClick={(e) => e.stopPropagation()}
                         className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors"

--- a/frontend/src/pages/Timeline.jsx
+++ b/frontend/src/pages/Timeline.jsx
@@ -116,7 +116,7 @@ export const Timeline = () => {
         let relative = path;
         const prefixes = ['/var/lib/motion/', '/var/lib/vibe/recordings/'];
         prefixes.forEach(p => { if (relative.startsWith(p)) relative = relative.replace(p, ''); });
-        return `${API_BASE}/media/${relative}`;
+        return `${API_BASE}/media/${relative}${token ? `?token=${token}` : ""}`;
     };
 
     const handleDelete = async (id) => {


### PR DESCRIPTION
## Problem

Three bugs that break core functionality on plain HTTP deployments:

### 1 & 2 — Video playback and file downloads return 401

`GET /api/media/{path}` and `GET /api/events/{id}/download` both require authentication. Browser-initiated requests (direct `<video src>` and `<a href>` navigation) cannot carry an `Authorization: Bearer` header — but both backend endpoints already accept a `token` query parameter for exactly this case. The frontend was not appending it.

### 3 — Session lost on every page refresh

`docker-compose.yml` sets `COOKIE_SECURE=${COOKIE_SECURE:-true}` — meaning the `auth_token` and `media_token` HttpOnly cookies are stamped with the `Secure` flag by default. Browsers silently drop `Secure` cookies on plain HTTP connections, so the session cookie is never sent back to the backend. The `GET /auth/me-from-cookie` bootstrap call (run on every page load) receives no cookie → 401 → user sees the login form again.

The backend already has correct auto-detection logic (`COOKIE_SECURE=auto` reads `X-Forwarded-Proto`). The compose default just must not override it with an unconditional `true`.

## Changes

**`frontend/src/components/Timeline/EventCard.jsx`**
- Destructure `token` from `useAuth()` (previously only `user`)
- Append `?token=${token}` to the download `<a href>`

**`frontend/src/pages/Timeline.jsx`**
- Append `?token=${token}` inside `getMediaUrl()` so every media URL sent to the player carries the token

**`docker-compose.yml`**
- Change `COOKIE_SECURE=${COOKIE_SECURE:-true}` → `${COOKIE_SECURE:-false}` so HTTP deployments work out of the box; HTTPS deployments can still override via their own `.env`

## Test plan

- [ ] Click a recorded video in Timeline — plays without 401
- [ ] Click Download on an event card — file downloads (not a JSON error response)
- [ ] Log in, refresh the page — session is preserved, no re-login required