### PR TITLE
fix(ui): resolve t is not defined in LogSettingsModal

### DIFF
--- a/frontend/src/pages/Logs.jsx
+++ b/frontend/src/pages/Logs.jsx
@@ -257,6 +257,7 @@ export const Logs = () => {
 
 // Sub-component for Settings Modal
 const LogSettingsModal = ({ isOpen, onClose, token, showToast }) => {
+    const { t } = useTranslation();
     const [settings, setSettings] = useState({
         log_max_size_mb: '50',
         log_backup_count: '5',


### PR DESCRIPTION
## Summary

The `LogSettingsModal` sub-component in `frontend/src/pages/Logs.jsx` uses `t('...')` in JSX but never calls `useTranslation()` in its own scope. The early `return null` for the closed-modal state hides the bug — as soon as the user clicks the Settings (gear) icon, the modal renders, the first `t(...)` call fires, and the page crashes with:

```
Uncaught ReferenceError: t is not defined
```

Same pattern as the earlier `VideoPlayer` fix in [`7149eb6`](https://github.com/spupuz/VibeNVR/commit/7149eb6).

## Fix

Add `const { t } = useTranslation();` at the top of the `LogSettingsModal` function body. One line.

## Test plan

- [ ] Go to `/logs`
- [ ] Click the Settings (gear) icon in the toolbar
- [ ] "Log Rotation Settings" modal opens with localized labels
- [ ] Console shows no `ReferenceError`