### PR TITLE
fix(ui): dark-mode adapt all overlay/transparent select dropdowns (Timeline + Live View)

### DIFF
--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -86,8 +86,8 @@ export const EventPreview = ({
                                     className="ml-1 h-3.5 text-[9px] bg-transparent border-none focus:ring-0 cursor-pointer text-muted-foreground hover:text-foreground p-0 pr-1 pl-1"
                                     title="Playback Order"
                                 >
-                                    <option value="desc">{t('timeline.newest_oldest', 'Newest → Oldest')}</option>
-                                    <option value="asc">{t('timeline.oldest_newest', 'Oldest → Newest')}</option>
+                                    <option value="desc" className="bg-card text-foreground">{t('timeline.newest_oldest', 'Newest → Oldest')}</option>
+                                    <option value="asc" className="bg-card text-foreground">{t('timeline.oldest_newest', 'Oldest → Newest')}</option>
                                 </select>
                             )}
                         </label>
@@ -126,9 +126,9 @@ export const EventPreview = ({
                                 className="bg-transparent text-xs font-black text-white/90 border-none focus:ring-0 cursor-pointer p-0 text-center w-8 appearance-none"
                                 title="Playback Speed"
                             >
-                                <option value={1} className="text-black">{t('timeline.1x', '1x')}</option>
-                                <option value={2} className="text-black">{t('timeline.2x', '2x')}</option>
-                                <option value={3} className="text-black">{t('timeline.3x', '3x')}</option>
+                                <option value={1} className="!bg-card !text-foreground">{t('timeline.1x', '1x')}</option>
+                                <option value={2} className="!bg-card !text-foreground">{t('timeline.2x', '2x')}</option>
+                                <option value={3} className="!bg-card !text-foreground">{t('timeline.3x', '3x')}</option>
                             </select>
                         </div>
                     )}
@@ -173,8 +173,8 @@ export const EventPreview = ({
                                 className="ml-1 h-5 text-[10px] bg-transparent border-none focus:ring-0 cursor-pointer text-muted-foreground hover:text-foreground p-0 pr-1 pl-1"
                                 title="Playback Order"
                             >
-                                <option value="desc">{t('timeline.newest_oldest', 'Newest → Oldest')}</option>
-                                <option value="asc">{t('timeline.oldest_newest', 'Oldest → Newest')}</option>
+                                <option value="desc" className="bg-card text-foreground">{t('timeline.newest_oldest', 'Newest → Oldest')}</option>
+                                <option value="asc" className="bg-card text-foreground">{t('timeline.oldest_newest', 'Oldest → Newest')}</option>
                             </select>
                         )}
                     </div>
@@ -188,9 +188,9 @@ export const EventPreview = ({
                                 className="bg-transparent text-xs font-bold text-foreground border-none focus:ring-0 cursor-pointer p-0 text-center w-12 appearance-none"
                                 title="Playback Speed"
                             >
-                                <option value={1}>{t('timeline.1x', '1x')}</option>
-                                <option value={2}>{t('timeline.2x', '2x')}</option>
-                                <option value={3}>{t('timeline.3x', '3x')}</option>
+                                <option value={1} className="!bg-card !text-foreground">{t('timeline.1x', '1x')}</option>
+                                <option value={2} className="!bg-card !text-foreground">{t('timeline.2x', '2x')}</option>
+                                <option value={3} className="!bg-card !text-foreground">{t('timeline.3x', '3x')}</option>
                             </select>
                         </div>
                     )}

--- a/frontend/src/pages/LiveView.jsx
+++ b/frontend/src/pages/LiveView.jsx
@@ -532,9 +532,9 @@ export const LiveView = () => {
                                     value={selectedGroup}
                                     onChange={(e) => setSelectedGroup(e.target.value)}
                                 >
-                                    <option value="all">{t('timeline.all', 'All')}</option>
+                                    <option value="all" className="bg-card text-foreground">{t('timeline.all', 'All')}</option>
                                     {availableGroups.map(g => (
-                                        <option key={g} value={g}>{g}</option>
+                                        <option key={g} value={g} className="bg-card text-foreground">{g}</option>
                                     ))}
                                 </select>
                             </div>
@@ -563,11 +563,11 @@ export const LiveView = () => {
                                 localStorage.setItem('liveViewColumns', val);
                             }}
                         >
-                            <option value="auto">{t('timeline.auto', 'Auto')}</option>
-                            <option value="1">{t('timeline.1_col', '1 Col')}</option>
-                            <option value="2">{t('timeline.2_cols', '2 Cols')}</option>
-                            <option value="3">{t('timeline.3_cols', '3 Cols')}</option>
-                            <option value="4">{t('timeline.4_cols', '4 Cols')}</option>
+                            <option value="auto" className="bg-card text-foreground">{t('timeline.auto', 'Auto')}</option>
+                            <option value="1" className="bg-card text-foreground">{t('timeline.1_col', '1 Col')}</option>
+                            <option value="2" className="bg-card text-foreground">{t('timeline.2_cols', '2 Cols')}</option>
+                            <option value="3" className="bg-card text-foreground">{t('timeline.3_cols', '3 Cols')}</option>
+                            <option value="4" className="bg-card text-foreground">{t('timeline.4_cols', '4 Cols')}</option>
                         </select>
                     </div>
 


### PR DESCRIPTION
## Problem

Several `<select>` dropdowns rendered with a white background in dark mode. They all share the same cause: the `<select>` uses `bg-transparent` (chips on a dark background), so browsers fall back to the default white `<option>` background when the dropdown opens.

Affected:
- **Timeline** (`EventPreview.jsx`): Auto-next direction, Playback speed (1x/2x/3x)
- **Live View** (`LiveView.jsx`): Group filter, Column layout selector (Auto / 1-4 Cols)

The pattern that already works correctly is in [`EventFilters.jsx`](https://github.com/spupuz/VibeNVR/blob/main/frontend/src/components/Timeline/EventFilters.jsx#L44) (camera/type/object filters) — there the `<select>` carries `bg-card text-foreground`.

## Fix

Add `bg-card text-foreground` to the `<option>` elements.

For the **Playback speed** options the parent `<select>` carries `text-white/90` (the closed-state chip label sits on the dark video overlay), which inherits into the dropdown — so those need `!bg-card !text-foreground` (`!important`) to override. The other selectors don't force a text color, so plain theme tokens are enough.

Closed-state chip styling is unchanged; only the expanded dropdowns become theme-aware, matching the existing `EventFilters` selectors.

## Test plan

- [ ] Timeline → select a video event in dark mode → speed dropdown (1x/2x/3x) is dark
- [ ] Timeline → Auto-next direction dropdown is dark
- [ ] Live View → column layout selector (Auto / Cols) is dark
- [ ] Live View → group filter dropdown is dark (when groups exist)
- [ ] Light mode unaffected (no regression)