### PR TITLE
fix(frontend): timeline date picker visibility and camera filter sync from URL

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,9 +49,14 @@
     --ring: 221.2 83.2% 53.3%;
 
     --radius: 0.5rem;
+
+    /* Make native widgets (date picker indicator, scrollbars, etc.) follow the theme */
+    color-scheme: light;
   }
 
   .dark {
+    color-scheme: dark;
+
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
 

--- a/frontend/src/pages/Timeline.jsx
+++ b/frontend/src/pages/Timeline.jsx
@@ -61,6 +61,16 @@ export const Timeline = () => {
         if (urlDate) setSelectedDate(urlDate);
     }, [urlDate]);
 
+    // Keep the filter dropdowns in sync with the URL (e.g. when navigating
+    // from Live View via /timeline?camera=<id>&type=video)
+    useEffect(() => {
+        setSelectedCameraFilter(cameraId || 'all');
+    }, [cameraId]);
+
+    useEffect(() => {
+        setSelectedTypeFilter(type || 'all');
+    }, [type]);
+
     const fetchEvents = useCallback(() => {
         let url = `${API_BASE}/events`;
         const params = new URLSearchParams();


### PR DESCRIPTION
## Problem

Two UI nits on the Timeline page:

1. **The date picker indicator is invisible on the dark theme.** The native `<input type="date">` renders its calendar indicator black because the page does not declare `color-scheme` — the browser assumes a light page.
2. **Navigating from Live View does not set the camera in the filter.** The Gallery/Videos buttons on a camera card link to `/timeline?camera=<id>&type=...` — the event list is filtered correctly (the params go into the API request), but the filter dropdowns stay on "All Cameras" / "All Media", which is confusing.

## Fix

- `index.css`: added `color-scheme: light` for `:root` and `color-scheme: dark` for `.dark` — all native widgets (calendar indicator and popup, scrollbars) now follow the theme.
- `Timeline.jsx`: the camera/type filter dropdown state is synced with the URL params (the same way it is already done for `date`).

## Verified

On my own instance (dark theme): the calendar icon is visible, navigating via the Videos button from Live View shows the selected camera and media type in the filters; Reset correctly clears both the state and the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)