### PR TITLE
fix(engine): honor "Motion Triggered" picture mode in the AI detection path

### DIFF
--- a/engine/camera_thread.py
+++ b/engine/camera_thread.py
@@ -227,7 +227,16 @@ class CameraThread(threading.Thread):
                                 detected_items = ", ".join([f"{r.get('label')} ({r.get('confidence', 0)*100:.0f}%)" for r in ai_results])
                                 logger.info(f"[AI DETECT] Camera {self.config.get('name')} (ID: {self.camera_id}): Motion START. Found: {detected_items}")
                                 
-                                snap_path = self.save_snapshot(frame, is_temp=True)
+                                # Honor "Motion Triggered" picture mode the same way the
+                                # OpenCV path does (motion_detector.py): save a permanent
+                                # snapshot with the AI boxes drawn on it. Otherwise keep
+                                # the temporary snapshot used only for notifications.
+                                if self.config.get('picture_recording_mode', 'Manual') == 'Motion Triggered':
+                                    snap_frame = frame.copy()
+                                    self._draw_ai_boxes(snap_frame, ai_results)
+                                    snap_path = self.save_snapshot(snap_frame, is_temp=False)
+                                else:
+                                    snap_path = self.save_snapshot(frame, is_temp=True)
                                 if self.event_callback:
                                     self.event_callback(self.camera_id, 'motion_start', {
                                         'source': f'AI Engine [{hw_label}]', 


### PR DESCRIPTION
## Problem

When `detect_engine = AI`, the "Motion Triggered" picture mode does not work: on detection the snapshot is saved only as a temporary file (for notifications), and no `snapshot` event is created. Combined with passthrough recording (where boxes on the video are not possible), the user never sees *what* the AI actually found.

## Fix

In the AI branch of `camera_thread.py`, when `picture_recording_mode == "Motion Triggered"`, a permanent snapshot is saved with the AI boxes drawn on it — the same way the OpenCV path already does it in `motion_detector.py`. Other modes are unchanged (temporary snapshot for notifications).

## Verified

On my own instance: person detection → snapshot with the box and confidence label in the Timeline, `snapshot` event in the DB. Other picture modes are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)