### PR TITLE
feat(go2rtc): route camera sub-streams through the gateway for AI inference

### DIFF
--- a/backend/motion_service.py
+++ b/backend/motion_service.py
@@ -29,6 +29,13 @@ def go2rtc_stream_name(camera_id) -> str:
     """Stable go2rtc stream name for a camera (survives renames)."""
     return f"cam_{camera_id}"
 
+
+def go2rtc_substream_name(camera_id) -> str:
+    """Stable go2rtc stream name for a camera's low-res sub-stream.
+    Registered separately so the engine can read it for AI inference while
+    recording/live still use the full-resolution main stream."""
+    return f"cam_{camera_id}_sub"
+
 # Global lock for camera synchronization
 sync_lock = threading.Lock()
 
@@ -176,9 +183,17 @@ def camera_to_config(cam: Camera, opt_settings: dict = None) -> dict:
         config["rtsp_url"] = f"rtsp://{GO2RTC_RTSP_HOST}/{stream}"
         # go2rtc republishes over TCP RTSP; force tcp for the engine hop.
         config["rtsp_transport"] = "tcp"
-        # The proxied stream is already the single source; drop sub-stream
-        # routing so the engine doesn't try to reach the camera directly.
-        config["sub_rtsp_url"] = None
+        # If the camera has a sub-stream, route it through go2rtc too (as a
+        # separate proxied stream) so the engine keeps reading the low-res
+        # sub-stream for AI inference instead of the camera directly. The
+        # engine never reaches the camera — both hops stay inside go2rtc.
+        # Without a sub-stream there is nothing to proxy, so drop it.
+        if cam.sub_rtsp_url and cam.sub_rtsp_url.strip():
+            sub_stream = go2rtc_substream_name(cam.id)
+            config["sub_rtsp_url"] = f"rtsp://{GO2RTC_RTSP_HOST}/{sub_stream}"
+            config["sub_rtsp_transport"] = "tcp"
+        else:
+            config["sub_rtsp_url"] = None
 
     return config
 
@@ -282,15 +297,11 @@ def sync_global_config(db: Session):
         logger.error(f"Error syncing global config: {e}")
         return False
 
-def _go2rtc_put_stream(camera) -> bool:
-    """Register/update a single camera's REAL url as a go2rtc stream via its API.
+def _go2rtc_put_one(name: str, src: str) -> bool:
+    """Register/update a single named go2rtc stream from a source URL.
     Idempotent — go2rtc replaces the source if the stream name already exists."""
-    src = camera.rtsp_url
-    if not src:
-        return False
-    # #timeout=15 makes go2rtc auto-reconnect if the camera stops sending data.
+    # #timeout=15 makes go2rtc auto-reconnect if the source stops sending data.
     src_with_opts = f"{src}#timeout=15"
-    name = go2rtc_stream_name(camera.id)
     try:
         # go2rtc's PUT /api/streams ADDS a source; calling it again for an
         # existing (especially actively-consumed) stream returns 400 and leaves
@@ -315,6 +326,18 @@ def _go2rtc_put_stream(camera) -> bool:
     except Exception as e:
         logger.error(f"go2rtc: error registering stream {name}: {e}")
         return False
+
+
+def _go2rtc_put_stream(camera) -> bool:
+    """Register a camera's main stream — and its sub-stream, if any — in go2rtc.
+    The sub-stream is published under a separate name so the engine can consume
+    it for AI inference while the main stream serves recording and live view."""
+    if not camera.rtsp_url:
+        return False
+    ok = _go2rtc_put_one(go2rtc_stream_name(camera.id), camera.rtsp_url)
+    if camera.sub_rtsp_url and camera.sub_rtsp_url.strip():
+        _go2rtc_put_one(go2rtc_substream_name(camera.id), camera.sub_rtsp_url.strip())
+    return ok
 
 
 def generate_go2rtc_config(db: Session):

--- a/engine/main.py
+++ b/engine/main.py
@@ -205,6 +205,7 @@ class CameraConfig(BaseModel):
     detect_motion_mode: str = "Always"
     detect_engine: str = "OpenCV"
     rtsp_transport: str = "tcp"
+    sub_rtsp_url: Optional[str] = None
     sub_rtsp_transport: str = "tcp"
     live_view_mode: str = "auto"
     audio_enabled: bool = False


### PR DESCRIPTION
@
## Problem

Two related issues:

1. **The sub-stream feature never actually worked** in v1.30.x. The engines `CameraConfig` model (`engine/main.py`) has no `sub_rtsp_url` field, so Pydantic silently dropped it from `/cameras/{id}/start`. All the sub-stream reading logic in `camera_thread.py` is present, but the value to enable it never arrived — `sub_rtsp_url` was always `None`.

2. **The go2rtc integration deliberately discarded the sub-stream.** When go2rtc is enabled, `camera_to_config()` nulled `sub_rtsp_url` and proxied only the main stream. As a result AI inference on every camera ran on the full-resolution stream — extra decoding and CPU.

## Changes

- `engine/main.py`: add `sub_rtsp_url: Optional[str] = None` to `CameraConfig` — a standalone fix that repairs the sub-stream feature independently of go2rtc.
- `backend/motion_service.py`: when go2rtc is on and the camera has a sub-stream, register it as a separate proxied stream `cam_<id>_sub` and point the engines `sub_rtsp_url` at that proxy. The engine reads the sub-stream for AI/motion/live; recording stays on the full-resolution main stream via passthrough. Every network hop stays inside go2rtc.

## How it works

In passthrough+sub-stream mode the engine already reads the low-res stream for processing and pulls the full-res stream for recording via a separate FFmpeg ([camera_thread.py:37](https://github.com/spupuz/VibeNVR/blob/main/engine/camera_thread.py#L37)). This change feeds the sub-stream there through go2rtc.

## Verified

On an instance with 3 cameras: a camera with a sub-stream now runs AI on 640×720 instead of 2304×2592, engine CPU dropped ~40%→30%, and recordings stayed full-resolution (2304×2592). Cameras without a sub-stream are unchanged.

## Known considerations (go2rtc sub-stream specifics)

1. **In passthrough mode the sub-stream becomes the engines only processing reader** (recording pulls main separately). So the sub-stream proxy is now a hard dependency for AI + live view: if go2rtc cannot reach the sub-stream source (wrong URL, camera busy, connection cap), AI and live view silently stop while recording on the main stream keeps working. `#timeout=15` makes go2rtc keep retrying the source and the engines StreamReader reconnects, so transient failures self-heal; only a permanently wrong URL leaves AI/live down (recording unaffected, so the symptom is at least diagnosable). This PR does not add a fallback for that case — flagging it for review.
2. **go2rtc opens a separate upstream connection for the sub-stream** (it is a distinct source). Cheap cameras with a hard simultaneous-connection cap — the very cameras go2rtc helps with — may hit that limit when both the main and sub streams are registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@