### PR TITLE
fix: resolve own lint and flake8 CI findings

### DIFF
--- a/engine/main.py
+++ b/engine/main.py
@@ -242,7 +242,6 @@ def health_check():
 @app.post("/config")
 def update_config(config: dict):
     """Update global engine configuration from backend"""
-    global GLOBAL_CONFIG
     logger.info(f"Updating global config: {config}")
     
     # Track what changed for AI

--- a/frontend/src/pages/Timeline.jsx
+++ b/frontend/src/pages/Timeline.jsx
@@ -23,9 +23,11 @@ export const Timeline = () => {
     const [cameraMap, setCameraMap] = useState({});
     const [searchParams, setSearchParams] = useSearchParams();
     const [cameras, setCameras] = useState([]);
-    const [selectedCameraFilter, setSelectedCameraFilter] = useState('all');
+    // Initialize the filter dropdowns from the URL so navigating in from Live
+    // View (/timeline?camera=<id>&type=video) shows the right selection on mount.
+    const [selectedCameraFilter, setSelectedCameraFilter] = useState(searchParams.get('camera') || 'all');
     const [selectedHour, setSelectedHour] = useState(null);
-    const [selectedTypeFilter, setSelectedTypeFilter] = useState('all');
+    const [selectedTypeFilter, setSelectedTypeFilter] = useState(searchParams.get('type') || 'all');
     const [selectedObjectFilter, setSelectedObjectFilter] = useState('all');
     const [selectedDate, setSelectedDate] = useState(new Date().toLocaleDateString('en-CA'));
     const { showToast } = useToast();
@@ -60,16 +62,6 @@ export const Timeline = () => {
     useEffect(() => {
         if (urlDate) setSelectedDate(urlDate);
     }, [urlDate]);
-
-    // Keep the filter dropdowns in sync with the URL (e.g. when navigating
-    // from Live View via /timeline?camera=<id>&type=video)
-    useEffect(() => {
-        setSelectedCameraFilter(cameraId || 'all');
-    }, [cameraId]);
-
-    useEffect(() => {
-        setSelectedTypeFilter(type || 'all');
-    }, [type]);
 
     const fetchEvents = useCallback(() => {
         let url = `${API_BASE}/events`;


### PR DESCRIPTION
@
Small fixes for two CI findings that originate from my own changes:

- **engine/main.py** — drop the unused `global GLOBAL_CONFIG` in `update_config`. The function only reads/mutates the dict, never rebinds it, so the declaration is a no-op that the stricter flake8 on CI flags (`F824`, which is in the blocking `--select`).
- **frontend Timeline.jsx** — initialize the camera/type filter dropdowns from the URL on mount instead of syncing them via `setState`-in-effect, clearing the two `react-hooks/set-state-in-effect` errors introduced in #47. Behaviour is unchanged — the dropdown `onChange` already updates both state and the URL, and navigating in from Live View mounts the page fresh.

Note: this does not make the CI fully green on its own — the frontend lint job still reports pre-existing errors across other files (see my comment on #52 for the full breakdown). This PR only clears the findings attributable to my own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@