### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Accessibility Issues
+**Learning:** Found several buttons in 'frontend/src/components/StorageProfileManager.jsx' and 'frontend/src/components/CameraScanner.jsx' that only contain icons and no `aria-label`. These include buttons for editing, deleting, or cancelling operations.
+**Action:** Always include `aria-label` for icon-only buttons to ensure they are accessible to screen reader users.

--- a/frontend/src/components/CameraScanner.jsx
+++ b/frontend/src/components/CameraScanner.jsx
@@ -439,7 +439,7 @@ export const CameraScanner = ({ onAddCamera, existingCameras = [] }) => {
                                             {t('cameras.add', 'Add')}
                                         </Button>
                                     )}
-                                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => handleProbe(dev)}>
+                                    <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => handleProbe(dev)} title={t('cameras.probe_device', 'Probe Device')} aria-label={t('cameras.probe_device', 'Probe Device')}>
                                         <ChevronRight className="w-5 h-5" />
                                     </Button>
                                 </div>
@@ -455,7 +455,7 @@ export const CameraScanner = ({ onAddCamera, existingCameras = [] }) => {
                     <div className="bg-card border-2 border-border rounded-2xl shadow-2xl max-w-md w-full overflow-hidden animate-in fade-in zoom-in duration-200">
                         <div className="p-6 border-b border-border flex justify-between items-center">
                             <h4 className="font-semibold text-lg">{t('cameras.probe_device', 'Probe Device:')} {probingDevice.ip}</h4>
-                            <Button variant="ghost" size="icon" onClick={() => setProbingDevice(null)}><X className="w-5 h-5" /></Button>
+                            <Button variant="ghost" size="icon" onClick={() => setProbingDevice(null)} title={t('common.close', 'Close')} aria-label={t('common.close', 'Close')}><X className="w-5 h-5" /></Button>
                         </div>
 
                         <div className="p-6">

--- a/frontend/src/components/StorageProfileManager.jsx
+++ b/frontend/src/components/StorageProfileManager.jsx
@@ -189,10 +189,10 @@ export const StorageProfileManager = () => {
                             {p.description && <p className="text-xs text-muted-foreground mt-0.5 truncate">{p.description}</p>}
                         </div>
                         <div className="flex items-center gap-1 sm:opacity-0 group-hover:opacity-100 transition-opacity self-end sm:self-auto">
-                            <Button variant="ghost" size="sm" onClick={() => handleEdit(p)} className="h-8 w-8 p-0 text-muted-foreground hover:text-primary">
+                            <Button variant="ghost" size="sm" onClick={() => handleEdit(p)} className="h-8 w-8 p-0 text-muted-foreground hover:text-primary" title={t('actions.edit', 'Edit')} aria-label={t('actions.edit', 'Edit')}>
                                 <Edit className="w-4 h-4" />
                             </Button>
-                            <Button variant="ghost" size="sm" onClick={() => handleDelete(p.id)} className="h-8 w-8 p-0 text-red-400 hover:text-red-500 hover:bg-red-50">
+                            <Button variant="ghost" size="sm" onClick={() => handleDelete(p.id)} className="h-8 w-8 p-0 text-red-400 hover:text-red-500 hover:bg-red-50" title={t('actions.delete', 'Delete')} aria-label={t('actions.delete', 'Delete')}>
                                 <Trash2 className="w-4 h-4" />
                             </Button>
                         </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons using the `t` translation function in `StorageProfileManager.jsx` and `CameraScanner.jsx`.
🎯 Why: To improve keyboard navigation and screen reader accessibility for interactive elements that only use icons.
♿ Accessibility: Improved screen reader announcements and provided visual tooltips on hover for icon-only buttons.

---
*PR created automatically by Jules for task [10113078361528262496](https://jules.google.com/task/10113078361528262496) started by @spupuz*