### PR TITLE
🎨 Palette: Add accessibility attributes to layout navigation

### DIFF
--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -89,6 +89,7 @@ export const Layout = ({ children, activeTab, onTabChange, theme, toggleTheme })
                     <button
                         onClick={() => setSidebarOpen(true)}
                         className="p-2 rounded-lg hover:bg-accent shrink-0"
+                        aria-label={t('layout.open_menu', 'Open menu')}
                     >
                         <Menu className="w-6 h-6" />
                     </button>

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 const SidebarItem = ({ icon: Icon, label, active, onClick }) => (
     <button
         onClick={onClick}
+        aria-current={active ? 'page' : undefined}
         className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg transition-all duration-200 group
       ${active
                 ? 'bg-primary/10 text-primary'
@@ -67,6 +68,7 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                 <button
                     onClick={onClose}
                     className="lg:hidden absolute top-4 right-4 p-2 rounded-lg hover:bg-accent"
+                    aria-label={t('layout.close_menu', 'Close menu')}
                 >
                     <X className="w-5 h-5" />
                 </button>


### PR DESCRIPTION
### 💡 What:
Added `aria-label`s to the mobile menu toggle buttons and an `aria-current` attribute to the active tab in the sidebar.

### 🎯 Why:
To improve screen reader compatibility and keyboard navigation accessibility. Icon-only buttons without `aria-label`s are not announced properly by assistive technologies. Also, `aria-current` clarifies which navigation link represents the active page.

### 📸 Before/After:
Before: `button`s in `<Layout>` and `<Sidebar>` had no accessible names, and `<SidebarItem>` links didn't explicitly communicate state to screen readers.
After: All are now properly labeled using the i18n translation function (`t`), and the current page is clearly indicated.

### ♿ Accessibility:
* Screen readers will now announce "Open menu" and "Close menu".
* Screen readers will announce the current page with "current page" context on the sidebar.

---
*PR created automatically by Jules for task [4229437303408988049](https://jules.google.com/task/4229437303408988049) started by @spupuz*