### PR TITLE
🎨 Palette: Improve keyboard accessibility and ARIA labels on Camera Cards

### DIFF
--- a/frontend/src/components/Cameras/CameraCard.jsx
+++ b/frontend/src/components/Cameras/CameraCard.jsx
@@ -23,11 +23,22 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
             {/* Selection Checkbox */}
             {user?.role === 'admin' && (
                 <div
-                    className={`absolute top-4 left-4 z-10 w-5 h-5 rounded border-2 flex items-center justify-center transition-all cursor-pointer ${isSelected ? 'bg-primary border-primary' : 'bg-background/80 border-border group-hover:border-primary/50'
+                    role="checkbox"
+                    aria-checked={isSelected}
+                    tabIndex={0}
+                    aria-label={t('camera.select', 'Select camera')}
+                    className={`absolute top-4 left-4 z-10 w-5 h-5 rounded border-2 flex items-center justify-center transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${isSelected ? 'bg-primary border-primary' : 'bg-background/80 border-border group-hover:border-primary/50'
                         }`}
                     onClick={(e) => {
                         e.stopPropagation();
                         onSelect?.(camera.id);
+                    }}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onSelect?.(camera.id);
+                        }
                     }}
                 >
                     {isSelected && (
@@ -129,6 +140,7 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
                         <Button
                             variant="ghost"
                             size="sm"
+                            aria-label={t('camera.export', 'Export camera settings')}
                             onClick={async () => {
                                 try {
                                     const res = await fetch(`/api/cameras/${camera.id}/export`, {
@@ -167,6 +179,7 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
                         <Button
                             variant="ghost"
                             size="sm"
+                            aria-label={t('camera.edit', 'Edit camera')}
                             onClick={() => onEdit(camera)}
                             className="p-2 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/40"
                             title="Edit Camera"
@@ -176,6 +189,7 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
                         <Button
                             variant="ghost"
                             size="sm"
+                            aria-label={t('camera.delete', 'Delete camera')}
                             onClick={() => onDelete(camera.id)}
                             className="p-2 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40"
                             title="Delete Camera"


### PR DESCRIPTION
💡 **What:** 
- Converted a custom selection `div` in the Camera Card into a proper accessible checkbox by adding `role="checkbox"`, `aria-checked`, `tabIndex={0}`, and `onKeyDown` (Space/Enter) handlers.
- Added localized `aria-label`s via the translation function (`t()`) to all icon-only buttons (Export, Edit, Delete, etc.) in the Camera Card.
- Added `focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` Tailwind classes to the checkbox for visual focus indication.
- Created `.Jules/palette.md` to document the learning that custom interactive elements (`div`s used as buttons/checkboxes) must receive roles, tab-indexing, and keydown handlers in this app.

🎯 **Why:** 
The application's camera selection process was inaccessible to keyboard and screen reader users. Screen readers could not announce the state of the selection checkbox or the purpose of icon-only action buttons, and keyboard users could not navigate to or interact with the camera selection.

📸 **Before/After:** 
Before: Keyboard focus skipped the camera selection check entirely, and screen readers read icon buttons as empty or just "Button".
After: Focus stops on the camera checkbox with a clear visual ring, Space/Enter toggles the selection, and all actions announce their specific purpose clearly.

♿ **Accessibility:** 
- Fixed WCAG 2.1.1 Keyboard (keyboard interactability).
- Fixed WCAG 4.1.2 Name, Role, Value (ARIA roles and checked state on custom div).
- Fixed WCAG 1.1.1 Non-text Content (ARIA labels on icon buttons).
- Fixed WCAG 2.4.7 Focus Visible (Tailwind focus styles).

---
*PR created automatically by Jules for task [101029585390658636](https://jules.google.com/task/101029585390658636) started by @spupuz*