### PR TITLE
🎨 Palette: EventCard Keyboard Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility Issues
 **Learning:** Found several buttons in 'frontend/src/components/StorageProfileManager.jsx' and 'frontend/src/components/CameraScanner.jsx' that only contain icons and no `aria-label`. These include buttons for editing, deleting, or cancelling operations.
 **Action:** Always include `aria-label` for icon-only buttons to ensure they are accessible to screen reader users.
+
+## 2024-05-18 - Timeline Event Card Accessibility Improvements
+**Learning:** Found an accessibility issue pattern specific to interactive event cards that heavily rely on standard div tags with `onClick` without native keyboard interactions. Utilizing standard `button` or `a` elements when possible is better, but when complex div structures are required for cards with multiple sub-actions (like checkboxes and individual delete/download buttons), adding `role="button"`, `tabIndex={0}`, localized `aria-label`s, and custom `onKeyDown` handlers is critical to support seamless screen reader and keyboard-only navigation. Furthermore, ensuring that multi-select UI elements are proper sematic buttons with `role="checkbox"` and `aria-checked` states significantly improves screen reader comprehension.
+**Action:** Next time working on complex card-based layouts with nested actions, ensure that the main card acts as a focal button and all nested interactive elements (like icon buttons) receive specific accessible focus treatments (`focus-visible` ring) and independent screen reader context.

--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Video, Image as ImageIcon, Download, Trash2, Camera, HardDrive, Brain } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Individual Event Card Component
@@ -16,6 +17,7 @@ import { useAuth } from '../../contexts/AuthContext';
  */
 export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected, onToggleSelect, getMediaUrl, onDelete }) => {
     const { user } = useAuth();
+    const { t } = useTranslation();
     const [imgError, setImgError] = useState(false);
     const time = new Date(event.timestamp_start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     const date = new Date(event.timestamp_start).toLocaleDateString([], { month: 'short', day: 'numeric' });
@@ -23,11 +25,26 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
     return (
         <div
             id={`event-${event.id}`}
-            className={`flex items-stretch bg-card border rounded-xl overflow-hidden cursor-pointer transition-all hover:shadow-lg group
+            className={`flex items-stretch bg-card border rounded-xl overflow-hidden cursor-pointer transition-all hover:shadow-lg group focus-within:ring-2 focus-within:ring-ring
                 ${isSelected ? 'ring-2 ring-primary border-primary' : 'border-border hover:border-primary/50'}
             `}
             onClick={() => onClick(event)}
         >
+            {/* Visually hidden but accessible primary action for screen readers */}
+            <button
+                className="sr-only"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onClick(event);
+                }}
+                aria-label={t('timeline.event_card_label', 'View {{type}} event from {{camera}} at {{time}}', {
+                    type: event.type,
+                    camera: camera?.name || `Camera ${event.camera_id}`,
+                    time: time
+                })}
+            >
+                View Event
+            </button>
             {/* Thumbnail */}
             <div className="w-24 sm:w-32 h-20 bg-black/10 flex-shrink-0 relative overflow-hidden">
                 {event.thumbnail_path && !imgError ? (
@@ -54,8 +71,11 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
 
                 {/* Selection Checkbox (Visible on hover or if multi-selected for Admins only) */}
                 {user?.role === 'admin' && (
-                    <div 
-                        className={`absolute top-2 left-2 z-20 transition-all cursor-pointer ${isMultiSelected ? 'opacity-100 scale-110' : 'opacity-0 group-hover:opacity-100'}`}
+                    <button
+                        role="checkbox"
+                        aria-checked={isMultiSelected}
+                        aria-label={t('timeline.select_event', 'Select event')}
+                        className={`absolute top-2 left-2 z-20 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-black/50 rounded-md ${isMultiSelected ? 'opacity-100 scale-110' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'}`}
                         onClick={(e) => {
                             e.stopPropagation();
                             onToggleSelect(event.id, e.shiftKey);
@@ -68,7 +88,7 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
                         }`}>
                             {isMultiSelected && <div className="w-2.5 h-2.5 bg-current rounded-sm" />}
                         </div>
-                    </div>
+                    </button>
                 )}
 
                 {/* Overlaid Actions (Visible on Hover) */}
@@ -78,8 +98,9 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
                         href={`/api/events/${event.id}/download`}
                         download
                         onClick={(e) => e.stopPropagation()}
-                        className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors"
-                        title="Download"
+                        className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-black/50"
+                        title={t('actions.download', 'Download')}
+                        aria-label={t('actions.download', 'Download')}
                     >
                         <Download className="w-3 h-3" />
                     </a>
@@ -91,8 +112,9 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
                                 e.stopPropagation();
                                 onDelete(event.id);
                             }}
-                            className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors"
-                            title="Delete"
+                            className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 focus-visible:ring-offset-black/50"
+                            title={t('actions.delete', 'Delete')}
+                            aria-label={t('actions.delete', 'Delete')}
                         >
                             <Trash2 className="w-3 h-3" />
                         </button>


### PR DESCRIPTION
💡 What: Improved keyboard and screen reader accessibility for `EventCard`.
🎯 Why: The nested structure of the EventCard relies on generic div containers making it completely invisible to screen-reader users attempting to view standard events, while the nested interactive actions lacked proper keyboard focus rings.
♿ Accessibility:
- Added `focus-within:ring-2` to the parent card to show focus when tabbing inside.
- Injected an `sr-only` dedicated `<button>` with a localized `aria-label` to act as the primary keyboard and screen-reader trigger.
- Added `focus-visible:ring-2` specifically designed focus styles to internal actions (like Delete, Download, and Select) for visual keyboard user feedback.

---
*PR created automatically by Jules for task [12654705396154793625](https://jules.google.com/task/12654705396154793625) started by @spupuz*