### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,5 @@
 ## 2025-02-23 - Accessibility Issues
 **Learning:** Found several buttons in 'frontend/src/components/StorageProfileManager.jsx' and 'frontend/src/components/CameraScanner.jsx' that only contain icons and no `aria-label`. These include buttons for editing, deleting, or cancelling operations.
-**Action:** Always include `aria-label` for icon-only buttons to ensure they are accessible to screen reader users.
+**Action:** Always include `aria-label` for icon-only buttons to ensure they are accessible to screen reader users.## 2026-06-15 - Added missing aria-labels to icon-only buttons
+**Learning:** Icon-only buttons used across the app (in Sidebar, Layout, Timeline EventPreview, EventCard, BulkActionBar, EventFilters) lack appropriate aria-labels and titles making them inaccessible to screen readers.
+**Action:** Added aria-label and title attributes to these elements using the useTranslation `t()` function to ensure screen reader accessibility while maintaining i18n support.

--- a/frontend/src/components/Timeline/BulkActionBar.jsx
+++ b/frontend/src/components/Timeline/BulkActionBar.jsx
@@ -55,7 +55,8 @@ export const BulkActionBar = ({
                     
                     <button
                         onClick={() => setSelectedIds(new Set())}
-                        title="Cancel"
+                        title={t('timeline.cancel', 'Cancel')}
+                        aria-label={t('timeline.cancel', 'Cancel')}
                         className="p-2 sm:px-3 sm:py-1.5 hover:bg-white/10 rounded-xl transition-colors"
                     >
                         <X className="w-4 h-4 sm:hidden" />

--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Video, Image as ImageIcon, Download, Trash2, Camera, HardDrive, Brain } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Individual Event Card Component
@@ -16,6 +17,7 @@ import { useAuth } from '../../contexts/AuthContext';
  */
 export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected, onToggleSelect, getMediaUrl, onDelete }) => {
     const { user } = useAuth();
+    const { t } = useTranslation();
     const [imgError, setImgError] = useState(false);
     const time = new Date(event.timestamp_start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     const date = new Date(event.timestamp_start).toLocaleDateString([], { month: 'short', day: 'numeric' });
@@ -92,7 +94,8 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
                                 onDelete(event.id);
                             }}
                             className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors"
-                            title="Delete"
+                            title={t('timeline.delete_event', 'Delete event')}
+                            aria-label={t('timeline.delete_event', 'Delete event')}
                         >
                             <Trash2 className="w-3 h-3" />
                         </button>

--- a/frontend/src/components/Timeline/EventFilters.jsx
+++ b/frontend/src/components/Timeline/EventFilters.jsx
@@ -136,6 +136,8 @@ export const EventFilters = ({
                 <button
                     onClick={() => setSelectedHour(null)}
                     className="px-3 py-2 text-sm bg-red-500/10 text-red-500 border border-red-500/20 rounded-xl hover:bg-red-500/20 transition-colors flex items-center gap-1.5"
+                    aria-label={t('timeline.clear_hour_filter', 'Clear hour filter')}
+                    title={t('timeline.clear_hour_filter', 'Clear hour filter')}
                 >
                     <span className="font-bold">{selectedHour}:00</span>
                     <span className="opacity-70">✕</span>

--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -94,6 +94,8 @@ export const EventPreview = ({
                         <button
                             onClick={() => setSelectedEvent(null)}
                             className="p-1 hover:bg-accent rounded-lg text-muted-foreground transition-colors"
+                            aria-label={t('timeline.close_preview', 'Close preview')}
+                            title={t('timeline.close_preview', 'Close preview')}
                         >
                             <X className="w-5 h-5" />
                         </button>
@@ -208,6 +210,8 @@ export const EventPreview = ({
                         <button
                             onClick={() => handleDelete(selectedEvent.id)}
                             className="p-1.5 hover:bg-destructive/10 text-muted-foreground hover:text-destructive rounded-lg transition-colors"
+                            aria-label={t('timeline.delete_event', 'Delete event')}
+                            title={t('timeline.delete_event', 'Delete event')}
                         >
                             <Trash2 className="w-4 h-4" />
                         </button>

--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -89,6 +89,8 @@ export const Layout = ({ children, activeTab, onTabChange, theme, toggleTheme })
                     <button
                         onClick={() => setSidebarOpen(true)}
                         className="p-2 rounded-lg hover:bg-accent shrink-0"
+                        aria-label={t('nav.open_menu', 'Open menu')}
+                        title={t('nav.open_menu', 'Open menu')}
                     >
                         <Menu className="w-6 h-6" />
                     </button>

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -67,6 +67,8 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                 <button
                     onClick={onClose}
                     className="lg:hidden absolute top-4 right-4 p-2 rounded-lg hover:bg-accent"
+                    aria-label={t('nav.close_menu', 'Close menu')}
+                    title={t('nav.close_menu', 'Close menu')}
                 >
                     <X className="w-5 h-5" />
                 </button>


### PR DESCRIPTION
Added missing `aria-label` and `title` attributes using translation strings (`t()`) to icon-only buttons across various components (Sidebar, Layout, EventPreview, EventCard, BulkActionBar, EventFilters). This improves screen reader accessibility and overall UX.

---
*PR created automatically by Jules for task [943324689038273591](https://jules.google.com/task/943324689038273591) started by @spupuz*