### PR TITLE
⚡ Bolt: [Performance improvement] Memoize Dashboard widget registry

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - React Render Optimization
+**Learning:** In React functional components, defining complex objects (like a registry of widgets that includes render functions) directly in the component body causes them to be recreated on every render. This forces re-renders of any child components relying on these objects or their functions, leading to unnecessary React reconciliation work.
+**Action:** Use `useMemo` to memoize large complex objects or configuration dictionaries that do not need to change on every render, ensuring stable object identities. Remember to correctly manage dependencies (such as translation functions, routing methods, state, and other memoized callbacks) to prevent stale closures.

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Activity, Camera, HardDrive, ShieldAlert, Film, Image, CalendarClock, Cpu, MemoryStick, Settings, GripVertical, GripHorizontal, Network, Database, Zap, Share2, Bot, Brain } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
@@ -216,7 +216,7 @@ export const Dashboard = () => {
         return () => clearInterval(interval);
     }, [token]);
 
-    const getCameraName = (id) => cameraMap[id] || `Camera ${id}`;
+    const getCameraName = useCallback((id) => cameraMap[id] || `Camera ${id}`, [cameraMap]);
 
     // Widget Definition Registry
     // Maps Widget ID -> { Component, Span, Group (for visibility) }
@@ -225,7 +225,9 @@ export const Dashboard = () => {
     // Span 3 = 1/4 (4 per row)
     // Span 6 = 1/2 (2 per row)
     // Span 12 = Full width
-    const WIDGET_REGISTRY = {
+    // ⚡ Bolt: Memoize the WIDGET_REGISTRY to prevent it and its render functions
+    // from being recreated on every re-render, reducing unnecessary React reconciliations.
+    const WIDGET_REGISTRY = useMemo(() => ({
         storage_movies: {
             span: 'col-span-12 md:col-span-6 lg:col-span-4',
             group: 'storage',
@@ -667,7 +669,7 @@ export const Dashboard = () => {
                 </div>
             )
         }
-    };
+    }), [stats, t, graphData, resourceHistory, recentEvents, getCameraName]);
 
     return (
         <div className="space-y-6">


### PR DESCRIPTION
💡 What: Wrapped `WIDGET_REGISTRY` in `useMemo` and `getCameraName` in `useCallback` inside `Dashboard.jsx`.
🎯 Why: In React, creating complex objects and inline arrow functions inside a component's render body causes them to have a new reference on every render. This forces unnecessary reconciliations for child components using this object.
📊 Impact: Reduces unnecessary React reconciliations for the widget components rendered by the dashboard.
🔬 Measurement: Verify by interacting with the dashboard (e.g. dragging widgets or fetching new data) and observing reduced memory allocation and React commit time in React DevTools.

---
*PR created automatically by Jules for task [166476521285627689](https://jules.google.com/task/166476521285627689) started by @spupuz*