### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in avatar upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Prevent Path Traversal in Avatar Uploads
+**Vulnerability:** Arbitrary file deletion vulnerability found in `backend/routers/users.py` where `os.remove(old_full_path)` was called after constructing a path with `os.path.join("/data", old_avatar)`.
+**Learning:** `os.path.join` and `os.remove` resolve relative path traversal strings (e.g. `../../etc/passwd`). Because users could update `avatar_path` via a profile update endpoint, they could trick the system into deleting arbitrary files when uploading a new avatar.
+**Prevention:** Always use `os.path.abspath()` on the constructed path and verify it `startswith()` the specific, intended directory (e.g. `/data/avatars/`) before passing it to filesystem modification functions.

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -175,7 +175,13 @@ def upload_avatar(
     if old_avatar:
         try:
             old_full_path = os.path.join("/data", old_avatar)
-            if os.path.exists(old_full_path) and old_full_path != file_path:
+            abs_old_path = os.path.abspath(old_full_path)
+
+            # Security: Prevent path traversal by ensuring the old avatar is actually in the avatars directory
+            if not abs_old_path.startswith("/data/avatars/"):
+                import logging
+                logging.warning(f"Security Alert: Blocked attempt to delete file outside avatars directory: {old_avatar}")
+            elif os.path.exists(old_full_path) and old_full_path != file_path:
                 os.remove(old_full_path)
         except Exception as e:
             print(f"Warning: Failed to delete old avatar {old_avatar}: {e}")


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in avatar upload cleanup

🚨 **Severity:** HIGH
💡 **Vulnerability:** An arbitrary file deletion vulnerability existed in `backend/routers/users.py` where `os.path.join` was used without checking for path traversals (like `../`) on `old_avatar`.
🎯 **Impact:** If a user modified their `avatar_path` to `../../etc/passwd` or similar and then uploaded a new avatar, the system would delete the targeted arbitrary file on the host.
🔧 **Fix:** Introduced a security check using `os.path.abspath()` to verify the computed file path strictly starts with `/data/avatars/` before passing it to `os.remove()`.
✅ **Verification:** Verified code compiles properly (`py_compile`) and test suite executes without regressions.

---
*PR created automatically by Jules for task [10892842088481490096](https://jules.google.com/task/10892842088481490096) started by @spupuz*