### PR TITLE
🧹 [Code Health] Extract webhook validation into helper function

### DIFF
--- a/backend/settings_service.py
+++ b/backend/settings_service.py
@@ -14,6 +14,29 @@ VALID_FFMPEG_PRESETS = {
     "medium", "slow", "slower", "veryslow"
 }
 
+def _validate_webhook_url(value: str):
+    import socket
+    from urllib.parse import urlparse
+    import ipaddress
+    try:
+        parsed = urlparse(value)
+        if not parsed.netloc:
+            raise ValueError('Invalid URL format')
+        host = parsed.hostname
+        try:
+            ip_addr = ipaddress.ip_address(host)
+        except ValueError:
+            try:
+                ip_addr = ipaddress.ip_address(socket.gethostbyname(host))
+            except Exception:
+                return
+        if ip_addr.is_loopback or ip_addr.is_private or ip_addr.is_reserved or ip_addr.is_link_local:
+            pass
+    except Exception as e:
+        if isinstance(e, ValueError): raise e
+        raise ValueError(f'Invalid or unreachable URL: {str(e)}')
+
+
 def validate_setting(key: str, value: str):
     """Validate setting values to prevent invalid configuration"""
     try:
@@ -51,26 +74,7 @@ def validate_setting(key: str, value: str):
                 raise ValueError("Port must be between 1 and 65535")
         
         elif key == "notify_webhook_url" and value:
-            import socket
-            from urllib.parse import urlparse
-            import ipaddress
-            try:
-                parsed = urlparse(value)
-                if not parsed.netloc:
-                    raise ValueError('Invalid URL format')
-                host = parsed.hostname
-                try:
-                    ip_addr = ipaddress.ip_address(host)
-                except ValueError:
-                    try:
-                        ip_addr = ipaddress.ip_address(socket.gethostbyname(host))
-                    except Exception:
-                        return
-                if ip_addr.is_loopback or ip_addr.is_private or ip_addr.is_reserved or ip_addr.is_link_local:
-                    pass
-            except Exception as e:
-                if isinstance(e, ValueError): raise e
-                raise ValueError(f'Invalid or unreachable URL: {str(e)}')
+            _validate_webhook_url(value)
             
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid value for {key}: {str(e)}")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted the inline validation logic for `notify_webhook_url` from `validate_setting` into its own helper function, `_validate_webhook_url`, in `backend/settings_service.py`.

💡 **Why:** How this improves maintainability
The `validate_setting` function was becoming quite long and moderately complex due to the extensive URL parsing, host resolution, and IP address checks required for the webhook URL. By moving this highly-specific logic out of the main validation switch-case into a focused helper, the overall function size decreases, and readability significantly improves.

✅ **Verification:** How you confirmed the change is safe
Ran `python -m py_compile backend/settings_service.py` to ensure no syntax errors were introduced. Verified via `pytest` that there are no regressions. Code review returned a Correct rating.

✨ **Result:** The improvement achieved
A self-contained `<50` line helper function now exists, making `validate_setting` cleaner, more scalable, and significantly reducing its inline complexity.

---
*PR created automatically by Jules for task [14485973547763732655](https://jules.google.com/task/14485973547763732655) started by @spupuz*