### PR TITLE
🧹 Refactor stats history endpoint to use aggregation helper

### DIFF
--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -453,6 +453,37 @@ def get_stats(db: Session = Depends(database.get_db), auth_info: tuple[models.Us
         }
     }
 
+def _aggregate_hourly_events(events: list, now: datetime) -> list[dict]:
+    """
+    Aggregates a list of events into hourly buckets for the last 24 hours.
+    """
+    history = {}
+    for i in range(25):
+        t = now - timedelta(hours=i)
+        key = t.strftime("%H:00")
+        history[key] = {"events": 0, "videos": 0}
+
+    for evt in events:
+        if not evt.timestamp_start:
+            continue
+        key = evt.timestamp_start.strftime("%H:00")
+        if key in history:
+            history[key]["events"] += 1
+            if evt.type == 'video':
+                history[key]["videos"] += 1
+
+    data = []
+    for i in range(24, -1, -1):
+        t = now - timedelta(hours=i)
+        key = t.strftime("%H:00")
+        if key in history:
+            data.append({
+                "time": key,
+                "events": history[key]["events"],
+                "videos": history[key]["videos"]
+            })
+    return data
+
 @router.get("/history")
 def get_stats_history(db: Session = Depends(database.get_db), auth_info: tuple[models.User, bool] = Depends(auth_service.get_current_user_or_token)):
     user, is_token = auth_info
@@ -475,41 +506,7 @@ def get_stats_history(db: Session = Depends(database.get_db), auth_info: tuple[m
             .filter(models.Event.timestamp_start >= twenty_four_hours_ago)\
             .all()
             
-        # Initialize buckets for last 24h
-        history = {}
-        # Pre-fill with 0
-        for i in range(25):
-            t = now - timedelta(hours=i)
-            key = t.strftime("%H:00")
-            history[key] = {"events": 0, "videos": 0}
-            
-        for evt in events:
-            if not evt.timestamp_start:
-                continue
-            key = evt.timestamp_start.strftime("%H:00")
-            # We might need to handle timezone if DB is UTC and local is not
-            # But usually naive datetimes in DB match logic.
-            # If the key isn't in history (slightly out of bounds due to minute diff), skip or find nearest.
-            if key in history:
-                history[key]["events"] += 1
-                if evt.type == 'video':
-                    history[key]["videos"] += 1
-        
-        # Convert to list sorted by time
-        data = []
-        # sort keys by time?
-        # Construct list from 24h ago to now
-        for i in range(24, -1, -1):
-            t = now - timedelta(hours=i)
-            key = t.strftime("%H:00")
-            if key in history:
-                data.append({
-                    "time": key,
-                    "events": history[key]["events"],
-                    "videos": history[key]["videos"]
-                })
-        
-        return data
+        return _aggregate_hourly_events(events, now)
 
     except Exception as e:
         print(f"Error generating history stats: {e}")


### PR DESCRIPTION
🎯 **What:** Extracted the complex hourly event aggregation and bucketing logic out of `get_stats_history` into a new, internal helper function `_aggregate_hourly_events`.

💡 **Why:** `get_stats_history` was long and tightly coupled to the data processing. This change extracts a small, self-contained piece of logic taking < 50 lines into its own testable, readable helper function.

✅ **Verification:** Verified that compilation is correct with `py_compile`. Functionality remains strictly identical since it just passes `events` and `now` into the exact same logical loop. Code review returned `#Correct#`.

✨ **Result:** Improved modularity and readability of the `backend/routers/stats.py` file, making `get_stats_history` much more concise.

---
*PR created automatically by Jules for task [8195080787429443278](https://jules.google.com/task/8195080787429443278) started by @spupuz*