### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/frontend/src/components/Cameras/CameraCard.jsx
+++ b/frontend/src/components/Cameras/CameraCard.jsx
@@ -160,7 +160,7 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
                                 }
                             }}
                             className="p-2 text-green-600 hover:bg-green-100 dark:hover:bg-green-900/40"
-                            title="Export Camera Settings"
+                            title="Export Camera Settings" aria-label="Export Camera Settings"
                         >
                             <Download className="w-5 h-5" />
                         </Button>
@@ -169,7 +169,7 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
                             size="sm"
                             onClick={() => onEdit(camera)}
                             className="p-2 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/40"
-                            title="Edit Camera"
+                            title="Edit Camera" aria-label="Edit Camera"
                         >
                             <Edit className="w-5 h-5" />
                         </Button>
@@ -178,7 +178,7 @@ export const CameraCard = ({ camera, onDelete, onEdit, onToggleActive, isSelecte
                             size="sm"
                             onClick={() => onDelete(camera.id)}
                             className="p-2 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40"
-                            title="Delete Camera"
+                            title="Delete Camera" aria-label="Delete Camera"
                         >
                             <Trash2 className="w-5 h-5" />
                         </Button>

--- a/frontend/src/pages/LiveView.jsx
+++ b/frontend/src/pages/LiveView.jsx
@@ -200,7 +200,7 @@ const VideoPlayer = ({
                 <button
                     onClick={handleExitFullscreen}
                     className="absolute top-4 right-4 z-[60] p-3 bg-black/70 hover:bg-black/90 text-white rounded-full shadow-2xl backdrop-blur-sm transition-all active:scale-90 border border-white/20"
-                    title="Exit Fullscreen"
+                    title="Exit Fullscreen" aria-label="Exit Fullscreen"
                 >
                     <X className="w-6 h-6" />
                 </button>
@@ -277,10 +277,10 @@ const VideoPlayer = ({
             {!showPTZ && (
                 <div className="absolute inset-x-0 bottom-0 p-2 z-40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex justify-center pointer-events-none">
                     <div className="flex items-center gap-0.5 sm:gap-1 bg-black/80 backdrop-blur-xl p-1 rounded-xl border border-white/10 shadow-3xl pointer-events-auto max-w-full overflow-hidden">
-                        <button onClick={() => onFocus(camera.id)} className={`p-1 rounded-md text-white transition-all shrink-0 ${isFocused ? 'bg-primary' : 'hover:bg-white/10'}`} title="Focus">
+                        <button onClick={() => onFocus(camera.id)} className={`p-1 rounded-md text-white transition-all shrink-0 ${isFocused ? 'bg-primary' : 'hover:bg-white/10'}`} title="Focus" aria-label="Focus">
                             <Square className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                         </button>
-                        <button onClick={handleFullscreen} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Fullscreen">
+                        <button onClick={handleFullscreen} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Fullscreen" aria-label="Fullscreen">
                             <Maximize2 className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                         </button>
 
@@ -294,16 +294,16 @@ const VideoPlayer = ({
                                     method: 'POST',
                                     headers: { Authorization: `Bearer ${token}` }
                                 }).then(res => { if (res.ok) showToast(`Snapshot saved`, 'success'); });
-                            }} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Take Photo">
+                            }} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Take Photo" aria-label="Take Photo">
                                 <Camera className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
                         )}
                         {hasPermission(camera, 'can_replay') && (
                             <>
-                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=snapshot`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Gallery">
+                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=snapshot`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Gallery" aria-label="Gallery">
                                     <ImageIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                                 </button>
-                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=video`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Videos">
+                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=video`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Videos" aria-label="Videos">
                                     <Play className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                                 </button>
                             </>
@@ -320,7 +320,7 @@ const VideoPlayer = ({
                                     onToggleRecording(camera);
                                 }}
                                 className={`p-1 rounded-md transition-all shrink-0 ${(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? 'bg-red-600 text-white animate-pulse shadow-[0_0_10px_rgba(220,38,38,0.5)]' : 'text-white hover:bg-red-600/50'}`}
-                                title={(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? "Stop Recording" : "Start Continuous Recording"}
+                                title={(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? "Stop Recording" : "Start Continuous Recording"} aria-label={(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? "Stop Recording" : "Start Continuous Recording"}
                             >
                                 <Disc className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
@@ -333,13 +333,13 @@ const VideoPlayer = ({
                                     setShowPTZ(!showPTZ);
                                 }}
                                 className={`p-1 rounded-md transition-all shrink-0 ${showPTZ ? 'bg-primary text-white shadow-[0_0_10px_rgba(var(--primary),0.5)]' : 'text-white hover:bg-primary/50'}`}
-                                title={showPTZ ? "Hide PTZ Controls" : "Show PTZ Controls"}
+                                title={showPTZ ? "Hide PTZ Controls" : "Show PTZ Controls"} aria-label={showPTZ ? "Hide PTZ Controls" : "Show PTZ Controls"}
                             >
                                 <Move className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
                         )}
                         {user?.role === 'admin' && (
-                            <button onClick={() => navigate(`/cameras?edit=${camera.id}`)} className="p-1 text-primary-foreground bg-primary hover:bg-primary/80 rounded-md transition-all shrink-0" title="Settings">
+                            <button onClick={() => navigate(`/cameras?edit=${camera.id}`)} className="p-1 text-primary-foreground bg-primary hover:bg-primary/80 rounded-md transition-all shrink-0" title="Settings" aria-label="Settings">
                                 <Settings className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
                         )}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only buttons in `LiveView.jsx` and `CameraCard.jsx`.
🎯 Why: Without text labels, icon-only buttons are invisible to screen readers, making critical camera actions (viewing, deleting, settings) inaccessible to visually impaired users.
♿ Accessibility: Ensures that screen reader users can interact with the main live player and camera cards effectively.

---
*PR created automatically by Jules for task [6572441911771559815](https://jules.google.com/task/6572441911771559815) started by @spupuz*