### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-28 - [CRITICAL] Prevent Path Traversal on File Deletion Endpoints
+**Vulnerability:** The avatar deletion endpoint allowed user-supplied input (`old_avatar` path fetched from the DB, which could potentially be manipulated by a malicious user setting their own avatar path) to be passed directly into `os.path.join("/data", old_avatar)` and then subsequently deleted.
+**Learning:** Due to how `os.path.join` works, absolute paths passed into the second parameter override the first parameter. A malicious string like `../../../../etc/passwd` or `/etc/passwd` would resolve outside the intended directory and allow deletion of arbitrary system files.
+**Prevention:** Always sanitize paths before filesystem operations. Use `os.path.abspath` to resolve the full intended path, and enforce strict boundary checking (e.g., `if path.startswith("/data/avatars/"):`) before performing any deletion or read operations.

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -174,8 +174,8 @@ def upload_avatar(
     # Delete old file if it exists and is different
     if old_avatar:
         try:
-            old_full_path = os.path.join("/data", old_avatar)
-            if os.path.exists(old_full_path) and old_full_path != file_path:
+            old_full_path = os.path.abspath(os.path.join("/data", old_avatar))
+            if old_full_path.startswith("/data/avatars/") and os.path.exists(old_full_path) and old_full_path != file_path:
                 os.remove(old_full_path)
         except Exception as e:
             print(f"Warning: Failed to delete old avatar {old_avatar}: {e}")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Traversal / Arbitrary File Deletion. The avatar deletion logic took a database path (`old_avatar`) and joined it with `/data`. Because `os.path.join` natively allows absolute paths to override the first argument, an attacker modifying their avatar path to something like `/etc/passwd` or using directory traversal sequences could cause the application to delete system files.
🎯 **Impact:** An authenticated user could potentially delete arbitrary files on the filesystem, leading to Denial of Service (DoS) or complete system compromise.
🔧 **Fix:** Sanitized the path resolution using `os.path.abspath()` and added a strict validation check (`startswith("/data/avatars/")`) before performing the `os.remove()` operation.
✅ **Verification:** Verified by running `ruff check` and syntax compilation on `backend/routers/users.py` and running the backend test suite (`pytest`).

---
*PR created automatically by Jules for task [10024718497991606077](https://jules.google.com/task/10024718497991606077) started by @spupuz*