### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -88,7 +88,7 @@ export const Layout = ({ children, activeTab, onTabChange, theme, toggleTheme })
                 <div className="lg:hidden sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border p-3 flex items-center justify-between w-full max-w-full overflow-hidden">
                     <button
                         onClick={() => setSidebarOpen(true)}
-                        className="p-2 rounded-lg hover:bg-accent shrink-0"
+                        className="p-2 rounded-lg hover:bg-accent shrink-0" aria-label={t('common.menu', 'Menu')}
                     >
                         <Menu className="w-6 h-6" />
                     </button>

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -66,7 +66,7 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                 {/* Close button for mobile - absolute positioned */}
                 <button
                     onClick={onClose}
-                    className="lg:hidden absolute top-4 right-4 p-2 rounded-lg hover:bg-accent"
+                    className="lg:hidden absolute top-4 right-4 p-2 rounded-lg hover:bg-accent" aria-label={t('common.close', 'Close')}
                 >
                     <X className="w-5 h-5" />
                 </button>
@@ -121,7 +121,7 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                             target="_blank"
                             rel="noopener noreferrer"
                             className="hover:text-foreground transition-colors"
-                            title="GitHub Repository"
+                            title="GitHub Repository" aria-label={t('sidebar.github_repository', 'GitHub Repository')}
                         >
                             <Github className="w-4 h-4" />
                         </a>
@@ -139,7 +139,7 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                             target="_blank"
                             rel="noopener noreferrer"
                             className="hover:text-yellow-500 transition-colors"
-                            title="Buy Me a Coffee"
+                            title="Buy Me a Coffee" aria-label={t('sidebar.buy_me_a_coffee', 'Buy Me a Coffee')}
                         >
                             <Coffee className="w-4 h-4" />
                         </a>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -678,7 +678,7 @@ export const Dashboard = () => {
                 </div>
                 <button
                     onClick={() => setShowWidgetModal(true)}
-                    className="p-2 hover:bg-muted rounded-lg transition-colors"
+                    className="p-2 hover:bg-muted rounded-lg transition-colors" aria-label={t('timeline.settings', 'Settings')}
                 >
                     <Settings className="w-5 h-5 text-muted-foreground" />
                 </button>

--- a/frontend/src/pages/LiveView.jsx
+++ b/frontend/src/pages/LiveView.jsx
@@ -200,7 +200,7 @@ const VideoPlayer = ({
                 <button
                     onClick={handleExitFullscreen}
                     className="absolute top-4 right-4 z-[60] p-3 bg-black/70 hover:bg-black/90 text-white rounded-full shadow-2xl backdrop-blur-sm transition-all active:scale-90 border border-white/20"
-                    title="Exit Fullscreen"
+                    title="Exit Fullscreen" aria-label={t('live.exit_fullscreen', 'Exit Fullscreen')}
                 >
                     <X className="w-6 h-6" />
                 </button>
@@ -277,10 +277,10 @@ const VideoPlayer = ({
             {!showPTZ && (
                 <div className="absolute inset-x-0 bottom-0 p-2 z-40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex justify-center pointer-events-none">
                     <div className="flex items-center gap-0.5 sm:gap-1 bg-black/80 backdrop-blur-xl p-1 rounded-xl border border-white/10 shadow-3xl pointer-events-auto max-w-full overflow-hidden">
-                        <button onClick={() => onFocus(camera.id)} className={`p-1 rounded-md text-white transition-all shrink-0 ${isFocused ? 'bg-primary' : 'hover:bg-white/10'}`} title="Focus">
+                        <button onClick={() => onFocus(camera.id)} className={`p-1 rounded-md text-white transition-all shrink-0 ${isFocused ? 'bg-primary' : 'hover:bg-white/10'}`} title="Focus" aria-label={t('live.focus', 'Focus')}>
                             <Square className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                         </button>
-                        <button onClick={handleFullscreen} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Fullscreen">
+                        <button onClick={handleFullscreen} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Fullscreen" aria-label={t('live.fullscreen', 'Fullscreen')}>
                             <Maximize2 className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                         </button>
 
@@ -300,10 +300,10 @@ const VideoPlayer = ({
                         )}
                         {hasPermission(camera, 'can_replay') && (
                             <>
-                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=snapshot`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Gallery">
+                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=snapshot`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Gallery" aria-label={t('live.gallery', 'Gallery')}>
                                     <ImageIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                                 </button>
-                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=video`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Videos">
+                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=video`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Videos" aria-label={t('live.videos', 'Videos')}>
                                     <Play className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                                 </button>
                             </>
@@ -339,7 +339,7 @@ const VideoPlayer = ({
                             </button>
                         )}
                         {user?.role === 'admin' && (
-                            <button onClick={() => navigate(`/cameras?edit=${camera.id}`)} className="p-1 text-primary-foreground bg-primary hover:bg-primary/80 rounded-md transition-all shrink-0" title="Settings">
+                            <button onClick={() => navigate(`/cameras?edit=${camera.id}`)} className="p-1 text-primary-foreground bg-primary hover:bg-primary/80 rounded-md transition-all shrink-0" title="Settings" aria-label={t('common.settings', 'Settings')}>
                                 <Settings className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
                         )}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -436,7 +436,7 @@ export const Profile = () => {
                                 <p className="text-sm text-muted-foreground">{t('timeline.scan_this_qr_code_with_yo', 'Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)')}</p>
                                 <div className="text-xs font-mono bg-muted p-2 rounded border border-border break-all select-all flex items-center justify-center gap-2">
                                     {setupData.secret}
-                                    <button onClick={() => navigator.clipboard.writeText(setupData.secret)} className="hover:text-primary" title="Copy Secret">
+                                    <button onClick={() => navigator.clipboard.writeText(setupData.secret)} className="hover:text-primary" title="Copy Secret" aria-label={t('profile.copy_secret', 'Copy Secret')}>
                                         <Copy className="w-3 h-3" />
                                     </button>
                                 </div>


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

**💡 What:** Added `aria-label` attributes using translation strings `t()` to icon-only buttons and links across several key components (`Layout`, `Sidebar`, `Dashboard`, `LiveView`, `Profile`).
**🎯 Why:** Icon-only buttons without `aria-label`s are invisible or confusing to screen readers, creating a major accessibility barrier. This change ensures visually impaired users can navigate and interact with the application effectively.
**♿ Accessibility:** Major improvement to WCAG compliance by ensuring all interactive elements have an accessible name.

---
*PR created automatically by Jules for task [9099131869987373593](https://jules.google.com/task/9099131869987373593) started by @spupuz*