### PR TITLE
🎨 Palette: Add aria-labels and tooltips to EventPreview buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-23 - Accessibility Issues
 **Learning:** Found several buttons in 'frontend/src/components/StorageProfileManager.jsx' and 'frontend/src/components/CameraScanner.jsx' that only contain icons and no `aria-label`. These include buttons for editing, deleting, or cancelling operations.
 **Action:** Always include `aria-label` for icon-only buttons to ensure they are accessible to screen reader users.
+## 2025-02-14 - Nested Interactive Elements in Complex UIs
+**Learning:** In dense data interfaces like the Timeline (`EventPreview`), icon-only interactive elements (like Close, Download, and Delete buttons) are prone to missing `aria-label` and `title` attributes, making them inaccessible to screen readers and confusing on hover. Because they are often nested within larger interactive containers or fast-moving flex layouts, this omission is easy to overlook.
+**Action:** Always verify that icon-only buttons (`<button>`, `<a>`) within overlay cards or timeline components include descriptive `aria-label` and `title` attributes. When possible, leverage existing i18n hooks (e.g., `t('common.<action>')`) to maintain localization consistency for accessibility labels.

--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -94,6 +94,8 @@ export const EventPreview = ({
                         <button
                             onClick={() => setSelectedEvent(null)}
                             className="p-1 hover:bg-accent rounded-lg text-muted-foreground transition-colors"
+                            title={t('common.close', 'Close')}
+                            aria-label={t('common.close', 'Close')}
                         >
                             <X className="w-5 h-5" />
                         </button>
@@ -201,6 +203,8 @@ export const EventPreview = ({
                         href={`/api/events/${selectedEvent.id}/download`}
                         download
                         className="p-1.5 hover:bg-accent rounded-lg text-muted-foreground hover:text-foreground transition-colors"
+                        title={t('common.download', 'Download')}
+                        aria-label={t('common.download', 'Download')}
                     >
                         <Download className="w-4 h-4" />
                     </a>
@@ -208,6 +212,8 @@ export const EventPreview = ({
                         <button
                             onClick={() => handleDelete(selectedEvent.id)}
                             className="p-1.5 hover:bg-destructive/10 text-muted-foreground hover:text-destructive rounded-lg transition-colors"
+                            title={t('common.delete', 'Delete')}
+                            aria-label={t('common.delete', 'Delete')}
                         >
                             <Trash2 className="w-4 h-4" />
                         </button>


### PR DESCRIPTION
🎨 Palette: Add aria-labels and tooltips to EventPreview buttons

💡 What: Added standard `aria-label` and `title` attributes to the Close, Download, and Delete icon-only buttons in the Timeline `EventPreview` component using existing i18n hooks.

🎯 Why: These interactive elements were previously icon-only without accessible names, making them invisible to screen readers and difficult to understand out of context on hover.

♿ Accessibility: Ensures that keyboard and screen reader users can identify the actions available for timeline events, adhering to standard WCAG guidelines for icon-only controls.

---
*PR created automatically by Jules for task [8637541509096761179](https://jules.google.com/task/8637541509096761179) started by @spupuz*