### PR TITLE
⚡ Bolt: Memoize Timeline components to prevent list re-renders

### DIFF
--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -14,7 +14,7 @@ import { useAuth } from '../../contexts/AuthContext';
  * @param {Function} props.getMediaUrl - Resolver for media URLs
  * @param {Function} props.onDelete - Handler for single event deletion
  */
-export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected, onToggleSelect, getMediaUrl, onDelete }) => {
+export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMultiSelected, onToggleSelect, getMediaUrl, onDelete }) => {
     const { user } = useAuth();
     const [imgError, setImgError] = useState(false);
     const time = new Date(event.timestamp_start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -26,7 +26,7 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
             className={`flex items-stretch bg-card border rounded-xl overflow-hidden cursor-pointer transition-all hover:shadow-lg group
                 ${isSelected ? 'ring-2 ring-primary border-primary' : 'border-border hover:border-primary/50'}
             `}
-            onClick={() => onClick(event)}
+            onClick={(e) => onClick(event, e)}
         >
             {/* Thumbnail */}
             <div className="w-24 sm:w-32 h-20 bg-black/10 flex-shrink-0 relative overflow-hidden">
@@ -175,4 +175,4 @@ export const EventCard = ({ event, onClick, camera, isSelected, isMultiSelected,
             </div>
         </div>
     );
-};
+});

--- a/frontend/src/components/Timeline/HourTimeline.jsx
+++ b/frontend/src/components/Timeline/HourTimeline.jsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
  * @param {Function} props.onHourClick - Handler for clicking an hour
  * @param {Number} props.selectedHour - Currently selected hour
  */
-export const HourTimeline = ({ events, onHourClick, selectedHour }) => {
+export const HourTimeline = React.memo(({ events, onHourClick, selectedHour }) => {
   const { t } = useTranslation();
     const hours = Array.from({ length: 24 }, (_, i) => 23 - i); // Newest at top
 
@@ -59,4 +59,4 @@ export const HourTimeline = ({ events, onHourClick, selectedHour }) => {
             </div>
         </div>
     );
-};
+});

--- a/frontend/src/pages/Timeline.jsx
+++ b/frontend/src/pages/Timeline.jsx
@@ -111,18 +111,18 @@ export const Timeline = () => {
         }
     }, [fetchEvents, fetchCameras, token]);
 
-    const getCamera = (id) => cameraMap[id];
-    const getCameraName = (id) => cameraMap[id]?.name || `Camera ${id}`;
+    const getCamera = useCallback((id) => cameraMap[id], [cameraMap]);
+    const getCameraName = useCallback((id) => cameraMap[id]?.name || `Camera ${id}`, [cameraMap]);
 
-    const getMediaUrl = (path) => {
+    const getMediaUrl = useCallback((path) => {
         if (!path) return '';
         let relative = path;
         const prefixes = ['/var/lib/motion/', '/var/lib/vibe/recordings/'];
         prefixes.forEach(p => { if (relative.startsWith(p)) relative = relative.replace(p, ''); });
         return `${API_BASE}/media/${relative}`;
-    };
+    }, []);
 
-    const handleDelete = async (id) => {
+    const handleDelete = useCallback(async (id) => {
         setConfirmConfig({
             isOpen: true,
             title: t('timeline.delete_event_title', 'Delete Event'),
@@ -140,7 +140,7 @@ export const Timeline = () => {
                             next.delete(id);
                             return next;
                         });
-                        if (selectedEvent?.id === id) setSelectedEvent(null);
+                        setSelectedEvent(prev => prev?.id === id ? null : prev);
                         showToast(t('timeline.event_deleted', 'Event deleted successfully'), 'success');
                     } else {
                         showToast(t('timeline.delete_failed', 'Failed to delete event'), 'error');
@@ -152,7 +152,7 @@ export const Timeline = () => {
             },
             onCancel: () => setConfirmConfig({ isOpen: false })
         });
-    };
+    }, [t, token, showToast]);
 
     const handleToggleSelect = useCallback((id, isShift) => {
         if (user?.role !== 'admin') return;
@@ -215,6 +215,18 @@ export const Timeline = () => {
         if (selectedIds.size === filteredEvents.length) setSelectedIds(new Set());
         else setSelectedIds(new Set(filteredEvents.map(e => e.id)));
     };
+
+    const handleHourClick = useCallback((h) => {
+        setSelectedHour(prev => prev === h ? null : h);
+    }, []);
+
+    const handleEventClick = useCallback((event, e) => {
+        if (user?.role === 'admin' && selectedIds.size > 0 && !e?.shiftKey) {
+            handleToggleSelect(event.id, false);
+        } else {
+            setSelectedEvent(event);
+        }
+    }, [user?.role, selectedIds.size, handleToggleSelect]);
 
     const groupedEvents = useMemo(() => {
         return filteredEvents.reduce((acc, event) => {
@@ -292,7 +304,7 @@ export const Timeline = () => {
 
                     <div className="flex-1 flex flex-col min-h-0">
                         <div className="flex-1 flex gap-2 min-h-0 p-3">
-                            <HourTimeline events={events} onHourClick={(h) => setSelectedHour(selectedHour === h ? null : h)} selectedHour={selectedHour} />
+                            <HourTimeline events={events} onHourClick={handleHourClick} selectedHour={selectedHour} />
                             <div className="flex-1 overflow-y-auto space-y-2 pr-1 text-[13px]">
                                 {filteredEvents.length === 0 ? (
                                     <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
@@ -307,7 +319,7 @@ export const Timeline = () => {
                                                 {dateEvents.map(event => (
                                                     <EventCard 
                                                         key={event.id} event={event} camera={getCamera(event.camera_id)} isSelected={selectedEvent?.id === event.id} isMultiSelected={selectedIds.has(event.id)}
-                                                        onClick={(e) => { if (user?.role === 'admin' && selectedIds.size > 0 && !e.shiftKey) handleToggleSelect(event.id, false); else setSelectedEvent(event); }}
+                                                        onClick={handleEventClick}
                                                         onToggleSelect={handleToggleSelect} getMediaUrl={getMediaUrl} onDelete={handleDelete}
                                                     />
                                                 ))}


### PR DESCRIPTION
💡 What: Wrapped `HourTimeline` and `EventCard` components with `React.memo` and extracted their callback functions (`onHourClick`, `onClick`) and prop dependencies (`getMediaUrl`, `handleDelete`, `getCamera`, `getCameraName`) in `Timeline.jsx` into stable `useCallback` references. 
🎯 Why: In the `Timeline` page, clicking on an event or during auto-playback, `selectedEvent` state updates. Because `Timeline` re-rendered, its children like the large list of `EventCard` components re-rendered, creating an inefficient re-render cycle, resulting in lag and high CPU usage. Memoization prevents these components from unnecessarily re-rendering.
📊 Impact: Reduces re-renders significantly on the `Timeline` page, leading to a much smoother user experience and reducing processing overhead.
🔬 Measurement: You can verify the optimization by enabling React Developer Tools' "Highlight updates when components render" option and observing that the `EventCard` components are no longer re-rendering unless actively selected or changed.

---
*PR created automatically by Jules for task [15265898817333539988](https://jules.google.com/task/15265898817333539988) started by @spupuz*