### PR TITLE
🎨 Palette: Add aria-labels to layout icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-23 - Accessibility Issues
 **Learning:** Found several buttons in 'frontend/src/components/StorageProfileManager.jsx' and 'frontend/src/components/CameraScanner.jsx' that only contain icons and no `aria-label`. These include buttons for editing, deleting, or cancelling operations.
 **Action:** Always include `aria-label` for icon-only buttons to ensure they are accessible to screen reader users.
+## 2025-02-23 - Layout Components Missing ARIA Labels
+**Learning:** Discovered icon-only buttons (like menu toggles and close buttons) and icon-only links (GitHub, Buy Me a Coffee) in global layout components (`Sidebar.jsx`, `Layout.jsx`) lacking `aria-label`s. Additionally, any added `aria-label` or `title` in these global components must be wrapped in `t()` for proper internationalization support.
+**Action:** Always add translated `aria-label` attributes to icon-only buttons and links in global layouts to guarantee screen reader accessibility across all languages.

--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -89,6 +89,7 @@ export const Layout = ({ children, activeTab, onTabChange, theme, toggleTheme })
                     <button
                         onClick={() => setSidebarOpen(true)}
                         className="p-2 rounded-lg hover:bg-accent shrink-0"
+                        aria-label={t('layout.open_sidebar', 'Open Sidebar')}
                     >
                         <Menu className="w-6 h-6" />
                     </button>

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -67,6 +67,7 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                 <button
                     onClick={onClose}
                     className="lg:hidden absolute top-4 right-4 p-2 rounded-lg hover:bg-accent"
+                    aria-label={t('nav.close_sidebar', 'Close Sidebar')}
                 >
                     <X className="w-5 h-5" />
                 </button>
@@ -121,7 +122,8 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                             target="_blank"
                             rel="noopener noreferrer"
                             className="hover:text-foreground transition-colors"
-                            title="GitHub Repository"
+                            title={t('nav.github_repo', 'GitHub Repository')}
+                            aria-label={t('nav.github_repo', 'GitHub Repository')}
                         >
                             <Github className="w-4 h-4" />
                         </a>
@@ -130,7 +132,8 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-xs hover:text-foreground font-mono tracking-wider transition-colors"
-                            title="View release on GitHub"
+                            title={t('nav.view_release', 'View release on GitHub')}
+                            aria-label={t('nav.view_release', 'View release on GitHub')}
                         >
                             v{packageJson.version}
                         </a>
@@ -139,7 +142,8 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
                             target="_blank"
                             rel="noopener noreferrer"
                             className="hover:text-yellow-500 transition-colors"
-                            title="Buy Me a Coffee"
+                            title={t('nav.buy_coffee', 'Buy Me a Coffee')}
+                            aria-label={t('nav.buy_coffee', 'Buy Me a Coffee')}
                         >
                             <Coffee className="w-4 h-4" />
                         </a>


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to icon-only buttons (mobile menu toggles) and links (GitHub, Buy Me a Coffee) in `Sidebar.jsx` and `Layout.jsx`.
🎯 **Why:** To improve accessibility for screen readers navigating the global layout components.
♿ **Accessibility:** Users relying on screen readers will now have context for these icon-only controls. The labels are also localized.

---
*PR created automatically by Jules for task [2205912245083032129](https://jules.google.com/task/2205912245083032129) started by @spupuz*