### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in avatar deletion

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-18 - [Fix path traversal vulnerability in avatar deletion]
+**Vulnerability:** Arbitrary file deletion due to missing path traversal protection in backend/routers/users.py when deleting an old avatar.
+**Learning:** The old_avatar variable was concatenated using os.path.join without verifying if the resulting absolute path stays within the intended /data/avatars directory. An attacker who could manipulate the db_user.avatar_path could exploit this to delete any file the backend process has permissions for.
+**Prevention:** Always use os.path.abspath and check if the resulting path startswith the intended directory (e.g. /data/avatars/) before calling os.remove.

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -174,8 +174,10 @@ def upload_avatar(
     # Delete old file if it exists and is different
     if old_avatar:
         try:
-            old_full_path = os.path.join("/data", old_avatar)
-            if os.path.exists(old_full_path) and old_full_path != file_path:
+            old_full_path = os.path.abspath(os.path.join("/data", old_avatar))
+            if not old_full_path.startswith("/data/avatars/"):
+                print(f"Security Alert: Blocked attempted deletion of file outside avatars directory: {old_full_path}")
+            elif os.path.exists(old_full_path) and old_full_path != file_path:
                 os.remove(old_full_path)
         except Exception as e:
             print(f"Warning: Failed to delete old avatar {old_avatar}: {e}")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing path traversal protection in avatar deletion
🎯 Impact: Arbitrary file deletion if an attacker was able to control the database state or inject paths into `avatar_path`
🔧 Fix: Used `os.path.abspath` and `startswith` validation
✅ Verification: Ran `pytest` suite locally and applied `ruff` checks.

Added a new file `.Jules/sentinel.md` documenting this learning.

---
*PR created automatically by Jules for task [9174262317046708567](https://jules.google.com/task/9174262317046708567) started by @spupuz*