### PR TITLE
🧪 Add test case for PyJWTError in get_current_user

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,19 @@
+import pytest
+from fastapi import HTTPException
+from unittest.mock import MagicMock
+
+import auth_service
+
+@pytest.mark.asyncio
+async def test_get_current_user_invalid_token():
+    # A malformed token that will raise jwt.PyJWTError (e.g. DecodeError)
+    invalid_token = "invalid.token.here"
+
+    # Mock db session
+    mock_db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.get_current_user(token=invalid_token, db=mock_db)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Could not validate credentials"


### PR DESCRIPTION
🎯 **What:** The testing gap for handling malformed JWT tokens causing `jwt.PyJWTError` in the `get_current_user` method was unaddressed.
📊 **Coverage:** A new unit test in `backend/tests/test_auth_service.py` (`test_get_current_user_invalid_token`) now safely tests this exact path, verifying an HTTP 401 response is accurately raised. The test suite is executed using `pytest`.
✨ **Result:** Test coverage improved for `get_current_user`. The PR also establishes initial backend test scaffolding by introducing `pytest.ini` with correct pathing rules.

---
*PR created automatically by Jules for task [17883564505451501759](https://jules.google.com/task/17883564505451501759) started by @spupuz*