### PR TITLE
fix(engine): ensure motion state persists accurately during AI persistence window

### DIFF
--- a/engine/camera_thread.py
+++ b/engine/camera_thread.py
@@ -271,6 +271,8 @@ class CameraThread(threading.Thread):
                         persist_window = min(motion_gap, 10.0) if self.motion_detector.motion_detected else 1.0
                         if (time.time() - self.last_ai_update_time) < persist_window:
                             ai_results = self.latest_ai_results
+                            # FIX: Ensure motion state persists during the AI persistence window
+                            self.motion_detector.last_motion_time = time.time()
                     
                     # Handle Motion End for AI
                     motion_gap = self.config.get('motion_gap', 10)


### PR DESCRIPTION
Fixed a bug in the video processing engine where the internal motion state could drop prematurely during the `persist_window`. When new AI results are missing during an inference frame but still within the configurable gap window, the UI relies on cached `latest_ai_results` to prevent flickering. However, the system's underlying clock tracking the overall `last_motion_time` wasn't being correctly updated in parallel. This patch adds the missing clock update to ensure recording triggers and motion sensors align cleanly with what's visibly happening on-screen.

---
*PR created automatically by Jules for task [18203454644809696380](https://jules.google.com/task/18203454644809696380) started by @spupuz*