### PR TITLE
🧪 Testing Improvement: Add edge case tests for go2rtc stream deletion

### DIFF
--- a/backend/tests/test_motion_service.py
+++ b/backend/tests/test_motion_service.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch, MagicMock
+from requests.exceptions import Timeout
+
+from backend.motion_service import _go2rtc_put_one, GO2RTC_API_URL
+
+
+def test_go2rtc_put_one_delete_timeout():
+    """Test that a timeout during requests.delete does not prevent the PUT request."""
+    with (
+        patch("backend.motion_service.requests.delete") as mock_delete,
+        patch("backend.motion_service.requests.put") as mock_put,
+    ):
+        mock_delete.side_effect = Timeout("Connection timed out")
+
+        mock_put.return_value = MagicMock(status_code=200)
+
+        result = _go2rtc_put_one("test_cam", "rtsp://test/stream")
+
+        # Verify result is True (success)
+        assert result is True
+
+        # Verify delete was called
+        mock_delete.assert_called_once_with(
+            f"{GO2RTC_API_URL}/api/streams", params={"name": "test_cam"}, timeout=10
+        )
+
+        # Verify put was still called despite the timeout in delete
+        mock_put.assert_called_once_with(
+            f"{GO2RTC_API_URL}/api/streams",
+            params={"name": "test_cam", "src": "rtsp://test/stream#timeout=15"},
+            timeout=10,
+        )
+
+
+def test_go2rtc_put_one_delete_exception():
+    """Test that a general exception during requests.delete does not prevent the PUT request."""
+    with (
+        patch("backend.motion_service.requests.delete") as mock_delete,
+        patch("backend.motion_service.requests.put") as mock_put,
+    ):
+        mock_delete.side_effect = Exception("General exception")
+
+        mock_put.return_value = MagicMock(status_code=200)
+
+        result = _go2rtc_put_one("test_cam", "rtsp://test/stream")
+
+        # Verify result is True (success)
+        assert result is True
+
+        # Verify delete was called
+        mock_delete.assert_called_once_with(
+            f"{GO2RTC_API_URL}/api/streams", params={"name": "test_cam"}, timeout=10
+        )
+
+        # Verify put was still called despite the exception in delete
+        mock_put.assert_called_once_with(
+            f"{GO2RTC_API_URL}/api/streams",
+            params={"name": "test_cam", "src": "rtsp://test/stream#timeout=15"},
+            timeout=10,
+        )
+
+
+def test_go2rtc_put_one_success():
+    """Test the happy path where both delete and put succeed."""
+    with (
+        patch("backend.motion_service.requests.delete") as mock_delete,
+        patch("backend.motion_service.requests.put") as mock_put,
+    ):
+        mock_delete.return_value = MagicMock(status_code=200)
+        mock_put.return_value = MagicMock(status_code=200)
+
+        result = _go2rtc_put_one("test_cam", "rtsp://test/stream")
+
+        assert result is True
+        mock_delete.assert_called_once()
+        mock_put.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces test coverage for the error handling mechanisms in `backend/motion_service.py:_go2rtc_put_one`. Specifically, it verifies the deliberate "best-effort" behavior of the `requests.delete` call which removes a stream from go2rtc. If the stream delete fails due to a timeout or connection issue, the code should suppress the error and safely proceed to create the stream via `requests.put`.

📊 **Coverage:** What scenarios are now tested
- Timeout failure on `requests.delete`
- Generic exception on `requests.delete`
- The expected "happy path" without errors

✨ **Result:** The improvement in test coverage
By adding `backend/tests/test_motion_service.py` with mocked HTTP requests, we ensure that the error-suppression behavior works deterministically and guarantees that future refactors won't inadvertently crash `_go2rtc_put_one` on minor stream deletion failures.

---
*PR created automatically by Jules for task [16530597864000200993](https://jules.google.com/task/16530597864000200993) started by @spupuz*