### PR TITLE
🎨 Palette: Localised ARIA labels and titles for BackupManager icon buttons

### DIFF
--- a/frontend/src/pages/Settings/BackupManager.jsx
+++ b/frontend/src/pages/Settings/BackupManager.jsx
@@ -201,14 +201,16 @@ export const BackupManager = () => {
                                                 <button 
                                                     onClick={() => handleRestore(b.filename)}
                                                     className="p-2 text-emerald-500 hover:bg-emerald-500/10 rounded-lg transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
-                                                    title="Restore"
+                                                    title={t('common.restore', 'Restore')}
+                                                    aria-label={t('common.restore', 'Restore')}
                                                 >
                                                     <RotateCcw className="w-5 h-5" />
                                                 </button>
                                                 <button 
                                                     onClick={() => handleDelete(b.filename)}
                                                     className="p-2 text-rose-500 hover:bg-rose-500/10 rounded-lg transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
-                                                    title="Delete"
+                                                    title={t('common.delete', 'Delete')}
+                                                    aria-label={t('common.delete', 'Delete')}
                                                 >
                                                     <Trash2 className="w-5 h-5" />
                                                 </button>
@@ -251,14 +253,16 @@ export const BackupManager = () => {
                                         <button 
                                             onClick={() => handleRestore(b.filename)}
                                             className="p-3 text-emerald-500 bg-emerald-500/10 rounded-xl border border-emerald-500/20 flex items-center justify-center min-h-[44px] min-w-[44px] active:scale-95 transition-all"
-                                            title="Restore"
+                                            title={t('common.restore', 'Restore')}
+                                            aria-label={t('common.restore', 'Restore')}
                                         >
                                             <RotateCcw className="w-5 h-5" />
                                         </button>
                                         <button 
                                             onClick={() => handleDelete(b.filename)}
                                             className="p-3 text-rose-500 bg-rose-500/10 rounded-xl border border-rose-500/20 flex items-center justify-center min-h-[44px] min-w-[44px] active:scale-95 transition-all"
-                                            title="Delete"
+                                            title={t('common.delete', 'Delete')}
+                                            aria-label={t('common.delete', 'Delete')}
                                         >
                                             <Trash2 className="w-5 h-5" />
                                         </button>


### PR DESCRIPTION
🎨 Palette: Localised ARIA labels and titles for BackupManager icon buttons

💡 What: Updated the "Restore" and "Delete" icon-only buttons in the BackupManager component to use `react-i18next` localized strings for their `aria-label` and `title` attributes.
🎯 Why: To ensure screen reader accessibility and tooltips properly support the app's internationalization, resolving the issue of hardcoded English strings on these interactive elements.
♿ Accessibility: Added `aria-label` attributes to ensure screen readers correctly interpret the icon-only buttons in both desktop and mobile views.

---
*PR created automatically by Jules for task [3258298946672843776](https://jules.google.com/task/3258298946672843776) started by @spupuz*