### PR TITLE
🧪 [testing] Add edge case tests for create_camera

### DIFF
--- a/.github/scripts/test_crud.py
+++ b/.github/scripts/test_crud.py
@@ -187,3 +187,84 @@ def test_get_events_no_matches(db, sample_data, monkeypatch):
 def test_get_events_pagination(db, sample_data):
     assert len(crud.get_events(db, limit=1)) == 1
     assert len(crud.get_events(db, skip=1)) == 2
+
+def test_create_camera_json_serialization(mocker):
+    # Mocking db session
+    db_mock = mocker.Mock()
+
+    # Mocking schema with list for ai_object_types
+    camera_data = {
+        "name": "Test Camera",
+        "rtsp_url": "rtsp://test",
+        "ai_object_types": ["person", "car"]
+    }
+
+    # We will use mocker to mock models.Camera
+    mocker.patch('models.Camera')
+
+    # Mock schema object
+    class DummyCameraSchema:
+        def dict(self):
+            return camera_data.copy()
+
+    camera_schema = DummyCameraSchema()
+
+    crud.create_camera(db_mock, camera_schema)
+
+    # Check that it serialized correctly
+    import json
+    expected_data = camera_data.copy()
+    expected_data['ai_object_types'] = json.dumps(["person", "car"])
+
+    models.Camera.assert_called_once_with(**expected_data)
+    db_mock.add.assert_called_once()
+    db_mock.commit.assert_called_once()
+
+def test_create_camera_no_ai_object_types(mocker):
+    # Mocking db session
+    db_mock = mocker.Mock()
+
+    # Mocking schema without ai_object_types
+    camera_data = {
+        "name": "Test Camera",
+        "rtsp_url": "rtsp://test"
+    }
+
+    mocker.patch('models.Camera')
+
+    class DummyCameraSchema:
+        def dict(self):
+            return camera_data.copy()
+
+    camera_schema = DummyCameraSchema()
+
+    crud.create_camera(db_mock, camera_schema)
+
+    models.Camera.assert_called_once_with(**camera_data)
+    db_mock.add.assert_called_once()
+    db_mock.commit.assert_called_once()
+
+def test_create_camera_string_ai_object_types(mocker):
+    # Mocking db session
+    db_mock = mocker.Mock()
+
+    # Mocking schema with string for ai_object_types
+    camera_data = {
+        "name": "Test Camera",
+        "rtsp_url": "rtsp://test",
+        "ai_object_types": "person, car" # This shouldn't be serialized to json
+    }
+
+    mocker.patch('models.Camera')
+
+    class DummyCameraSchema:
+        def dict(self):
+            return camera_data.copy()
+
+    camera_schema = DummyCameraSchema()
+
+    crud.create_camera(db_mock, camera_schema)
+
+    models.Camera.assert_called_once_with(**camera_data)
+    db_mock.add.assert_called_once()
+    db_mock.commit.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The missing edge case tests for `create_camera` in `backend/crud.py` have been added to the test suite in `.github/scripts/test_crud.py`.
📊 **Coverage:** Covered scenarios where `ai_object_types` is provided as a list (ensuring JSON serialization), omitted, or passed as a string (bypassing serialization).
✨ **Result:** Test coverage improved, ensuring future refactors won't break the conditional JSON serialization of the `ai_object_types` property on creation.

---
*PR created automatically by Jules for task [12645531965720948236](https://jules.google.com/task/12645531965720948236) started by @spupuz*