### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-20 - Missing ARIA labels on common Lucide close icons
+**Learning:** Found an accessibility pattern across the application where the `lucide-react` `<X />` icon was used for closing modals/toast notifications but the parent `<button>` lacked an `aria-label`. Because `X` is used purely visually, screen readers did not have an accessible name for these close actions.
+**Action:** Always ensure that icon-only interactive elements (like an `X` for close or `Trash` for delete) have a clear and explicit `aria-label` (using localized text via `t()` where available, e.g., `aria-label={t('common.close', 'Close')}`).

--- a/frontend/src/components/Cameras/AddEditModal/CameraAddEditModal.jsx
+++ b/frontend/src/components/Cameras/AddEditModal/CameraAddEditModal.jsx
@@ -129,6 +129,7 @@ export const CameraAddEditModal = ({
                         <button
                             onClick={() => { setShowAddModal(false); setEditingId(null); setCloneSourceId(''); }}
                             className="p-2 hover:bg-muted rounded-full transition-colors"
+                            aria-label={t('common.close', 'Close')}
                         >
                             <X className="w-5 h-5" />
                         </button>

--- a/frontend/src/components/Cameras/ImportSelectionModal.jsx
+++ b/frontend/src/components/Cameras/ImportSelectionModal.jsx
@@ -48,7 +48,7 @@ export const ImportSelectionModal = ({ showModal, onClose, onConfirm, cameras })
                             {t('cameras.import_selection_desc', 'Choose which cameras you want to import from the file.')}
                         </p>
                     </div>
-                    <button onClick={onClose} className="p-2 text-muted-foreground hover:bg-muted rounded-lg transition-colors">
+                    <button onClick={onClose} className="p-2 text-muted-foreground hover:bg-muted rounded-lg transition-colors" aria-label={t('common.close', 'Close')}>
                         <X className="w-5 h-5" />
                     </button>
                 </div>

--- a/frontend/src/contexts/ToastContext.jsx
+++ b/frontend/src/contexts/ToastContext.jsx
@@ -63,6 +63,7 @@ const Toast = ({ message, type, onClose }) => {
             <button
                 onClick={onClose}
                 className="p-1 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 text-muted-foreground transition-colors"
+                aria-label="Close"
             >
                 <X className="w-4 h-4" />
             </button>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -329,7 +329,7 @@ export const Profile = () => {
                                 <Key className="w-5 h-5 text-primary" />
                                 Change Password
                             </h3>
-                            <button onClick={() => setPwdModalOpen(false)} className="text-muted-foreground hover:text-foreground">
+                            <button onClick={() => setPwdModalOpen(false)} className="text-muted-foreground hover:text-foreground" aria-label={t('common.close', 'Close')}>
                                 <X className="w-5 h-5" />
                             </button>
                         </div>
@@ -382,7 +382,7 @@ export const Profile = () => {
                                 <Shield className="w-5 h-5 text-red-500" />
                                 Disable Two-Factor Authentication
                             </h3>
-                            <button onClick={() => { setDisable2FAModalOpen(false); setDisable2FAPassword(''); }} className="text-muted-foreground hover:text-foreground">
+                            <button onClick={() => { setDisable2FAModalOpen(false); setDisable2FAPassword(''); }} className="text-muted-foreground hover:text-foreground" aria-label={t('common.close', 'Close')}>
                                 <X className="w-5 h-5" />
                             </button>
                         </div>
@@ -422,7 +422,7 @@ export const Profile = () => {
                                 <Smartphone className="w-5 h-5 text-primary" />
                                 Setup 2FA
                             </h3>
-                            <button onClick={() => { setIs2FASetupOpen(false); setSetupCode(''); }} className="text-muted-foreground hover:text-foreground">
+                            <button onClick={() => { setIs2FASetupOpen(false); setSetupCode(''); }} className="text-muted-foreground hover:text-foreground" aria-label={t('common.close', 'Close')}>
                                 <X className="w-5 h-5" />
                             </button>
                         </div>

--- a/frontend/src/pages/Settings/EditUserModal.jsx
+++ b/frontend/src/pages/Settings/EditUserModal.jsx
@@ -28,6 +28,7 @@ export const EditUserModal = ({
                     <button
                         onClick={onClose}
                         className="text-muted-foreground hover:text-foreground transition-colors"
+                        aria-label={t('common.close', 'Close')}
                     >
                         <X className="w-5 h-5" />
                     </button>

--- a/frontend/src/pages/Settings/PasswordChangeModal.jsx
+++ b/frontend/src/pages/Settings/PasswordChangeModal.jsx
@@ -24,6 +24,7 @@ export const PasswordChangeModal = ({
                     <button
                         onClick={onClose}
                         className="text-muted-foreground hover:text-foreground transition-colors"
+                        aria-label="Close"
                     >
                         <X className="w-5 h-5" />
                     </button>

--- a/frontend/src/pages/Settings/SyncResultModal.jsx
+++ b/frontend/src/pages/Settings/SyncResultModal.jsx
@@ -22,6 +22,7 @@ export const SyncResultModal = ({
                     <button
                         onClick={onClose}
                         className="text-muted-foreground hover:text-foreground"
+                        aria-label={t('common.close', 'Close')}
                     >
                         <X className="w-5 h-5" />
                     </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label={t('common.close', 'Close')}` (or `aria-label="Close"`) to icon-only `<button>`s containing the Lucide `<X />` icon across several frontend components (Profile, Modals, ToastContext).

🎯 **Why:** Icon-only buttons without an accessible name are not properly announced by screen readers, creating an accessibility barrier for users relying on assistive technology. This change provides explicit, readable context to these previously opaque actions.

♿ **Accessibility:**
- Ensures screen readers announce the action as "Close" (or localized equivalent) instead of "button".
- Follows the application's existing localization pattern.
- Satisfies WCAG guidelines for Name, Role, Value.

---
*PR created automatically by Jules for task [7435006343356583234](https://jules.google.com/task/7435006343356583234) started by @spupuz*