### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/ApiTokenManager.jsx
+++ b/frontend/src/components/ApiTokenManager.jsx
@@ -246,6 +246,7 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                                             onClick={() => setConfirmDelete({ isOpen: true, tokenId: apiToken.id })}
                                             className="p-2 hover:bg-red-100 text-red-500 rounded-lg transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center ml-auto"
                                             title="Revoke Token"
+                                            aria-label="Revoke Token"
                                         >
                                             <Trash2 className="w-5 h-5" />
                                         </button>
@@ -282,6 +283,7 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                                     onClick={() => setConfirmDelete({ isOpen: true, tokenId: apiToken.id })}
                                     className="p-3 bg-red-500/10 text-red-500 rounded-lg hover:bg-red-500/20 transition-colors min-w-[44px] min-h-[44px]"
                                     title="Revoke Token"
+                                    aria-label="Revoke Token"
                                 >
                                     <Trash2 className="w-5 h-5" />
                                 </button>

--- a/frontend/src/components/Timeline/BulkActionBar.jsx
+++ b/frontend/src/components/Timeline/BulkActionBar.jsx
@@ -56,6 +56,7 @@ export const BulkActionBar = ({
                     <button
                         onClick={() => setSelectedIds(new Set())}
                         title="Cancel"
+                        aria-label="Cancel selection"
                         className="p-2 sm:px-3 sm:py-1.5 hover:bg-white/10 rounded-xl transition-colors"
                     >
                         <X className="w-4 h-4 sm:hidden" />

--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -80,6 +80,7 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                         onClick={(e) => e.stopPropagation()}
                         className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors"
                         title="Download"
+                        aria-label="Download"
                     >
                         <Download className="w-3 h-3" />
                     </a>
@@ -93,6 +94,7 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                             }}
                             className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors"
                             title="Delete"
+                            aria-label="Delete"
                         >
                             <Trash2 className="w-3 h-3" />
                         </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the 'Download' and 'Delete' icon-only buttons in `EventCard.jsx`, the 'Cancel' button in `BulkActionBar.jsx`, and the 'Revoke Token' buttons in `ApiTokenManager.jsx`.
🎯 Why: To improve the accessibility of the interface for screen reader users by ensuring all interactive elements have an accessible name, a core UX micro-improvement.
♿ Accessibility: Ensures that screen reader users can understand the function of icon-only buttons.

---
*PR created automatically by Jules for task [15278896131077866113](https://jules.google.com/task/15278896131077866113) started by @spupuz*