### PR TITLE
⚡ Bolt: Optimize get_users API with selectinload

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session, selectinload
-import models, schemas
+import models
+import schemas
 
 def get_camera(db: Session, camera_id: int):
     return db.query(models.Camera).filter(models.Camera.id == camera_id).first()
@@ -107,7 +108,13 @@ def get_user_by_email(db: Session, email: str):
     return db.query(models.User).filter(models.User.email == email).first()
 
 def get_users(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(models.User).offset(skip).limit(limit).all()
+    # Performance Optimization: Use selectinload to eagerly load camera_accesses
+    # and group_accesses relationships. This resolves an N+1 query issue during
+    # API serialization, significantly reducing DB query count from O(N) to O(1).
+    return db.query(models.User).options(
+        selectinload(models.User.camera_accesses).selectinload(models.UserCameraAccess.camera),
+        selectinload(models.User.group_accesses).selectinload(models.UserGroupAccess.group)
+    ).offset(skip).limit(limit).all()
 
 def create_user(db: Session, user: schemas.UserCreate):
     # Import here to avoid circular dependency


### PR DESCRIPTION
💡 What: Updated `backend/crud.py` to use `selectinload` for relationships inside the `get_users` query.
🎯 Why: To fix an N+1 query performance bottleneck that occurred during `read_users` API object serialization, preventing one DB query per user for fetching their respective camera and group accesses.
📊 Impact: Reduces queries in the API call from O(N) to O(1) by batching relation fetches.
🔬 Measurement: Verified functionality and correctness through `test_crud.py` testing and local `pnpm test` equivalents. Codebase linters run with zero new errors.

---
*PR created automatically by Jules for task [7666737646253580626](https://jules.google.com/task/7666737646253580626) started by @spupuz*