### PR TITLE
🛡️ Sentinel: Add HTTP Security Headers Middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Missing Default Security Headers in FastAPI
+**Vulnerability:** The application was missing basic defense-in-depth security headers (like X-Frame-Options: DENY, Strict-Transport-Security, X-Content-Type-Options: nosniff, and X-XSS-Protection) on its HTTP responses.
+**Learning:** By default, FastAPI/Starlette does not inject these standard security headers. Since the app might be exposed directly or via proxies that don't enforce them, it's essential to add them at the application level.
+**Prevention:** A custom middleware `add_security_headers` should be added to the `FastAPI` instance to ensure all responses globally get these headers without having to configure a reverse proxy.

--- a/backend/main.py
+++ b/backend/main.py
@@ -328,6 +328,15 @@ async def log_websocket_attempts(request: Request, call_next):
         logger.debug(f"[WS-HEADERS] {dict(request.headers)}")
     return await call_next(request)
 
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    return response
+
 # Rate Limiter setup
 limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter


### PR DESCRIPTION
**Vulnerability**: The FastAPI backend was missing standard defense-in-depth security headers on HTTP responses, such as `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security`, and `X-XSS-Protection`.

**Impact**: 
- Missing `X-Frame-Options` enables Clickjacking attacks (where an attacker frames the application to trick users into performing actions).
- Missing `X-Content-Type-Options: nosniff` can lead to MIME-sniffing vulnerabilities, where a browser might incorrectly interpret an uploaded benign file as an executable script.
- Missing `Strict-Transport-Security` means browsers won't automatically enforce HTTPS on subsequent visits, increasing the risk of Man-in-the-Middle (MitM) attacks.

**Fix**: Implemented a global `@app.middleware("http")` in `backend/main.py` that injects these standard security headers into every outgoing response.

**Verification**: Ran `pytest` with a custom test script to verify that the headers are correctly applied to the root endpoint (`/`). Tests passed successfully.

---
*PR created automatically by Jules for task [6467080326501268727](https://jules.google.com/task/6467080326501268727) started by @spupuz*