### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-19 - Removed Hardcoded Default SECRET_KEY
+**Vulnerability:** The application was falling back to a known hardcoded string (`"vibenvr-super-secret-key-change-me"`) for its JWT `SECRET_KEY` if the environment variable was omitted. This allowed potential attackers to forge valid JWT tokens and bypass authentication entirely if an instance was carelessly deployed.
+**Learning:** Hardcoded cryptographic keys or secrets should never be left as defaults in production code, even as placeholders or "dev" hints. Providing a fallback string inadvertently creates a backdoor for misconfigured deployments.
+**Prevention:** If a cryptographic secret must be generated on the fly when missing, use a secure random generator (like `secrets.token_urlsafe(32)`) to ensure the fallback is unique per runtime, keeping the instance secure (at the cost of token invalidation on restart, which encourages proper setup).

--- a/backend/auth_service.py
+++ b/backend/auth_service.py
@@ -9,9 +9,10 @@ import crud, database, models
 
 import os
 import pyotp
+import secrets
 
 # Secret key for JWT (Should be in env var in production)
-SECRET_KEY = os.getenv("SECRET_KEY", "vibenvr-super-secret-key-change-me")
+SECRET_KEY = os.getenv("SECRET_KEY", secrets.token_urlsafe(32))
 IS_WEAK_KEY = False
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 2  # 48 hours (Reduced from 7 days for security)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The backend `SECRET_KEY` utilized a publicly known, hardcoded string (`"vibenvr-super-secret-key-change-me"`) as a fallback if the environment variable was missing.
🎯 **Impact:** If an instance was improperly deployed without specifying a secret key, an attacker could trivially forge valid JWT tokens and gain full administrative access to the system.
🔧 **Fix:** Replaced the static fallback with `secrets.token_urlsafe(32)`. Instances missing the environment variable will now generate a secure, ephemeral key at runtime, preventing token forgery at the cost of resetting active sessions on restart (fail securely).
✅ **Verification:** Backend Python linters (`ruff check`) and tests pass successfully. Frontend linter and builder (`pnpm lint`, `pnpm build`) pass. A security journal entry has been documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12626641756687658567](https://jules.google.com/task/12626641756687658567) started by @spupuz*