### PR TITLE
🎨 Palette: Enhance Accessibility with ARIA Labels and States

### DIFF
--- a/frontend/src/components/GroupsManager.jsx
+++ b/frontend/src/components/GroupsManager.jsx
@@ -353,6 +353,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                             onClick={() => openManageModal(group)}
                                             className="p-2 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/40 rounded-lg transition-colors"
                                             title="Edit Group"
+                                            aria-label="Edit Group"
                                         >
                                             <Edit className="w-5 h-5" />
                                         </button>
@@ -360,6 +361,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                             onClick={() => handleDeleteGroup(group.id)}
                                             className="p-2 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40 rounded-lg transition-colors"
                                             title="Delete Group"
+                                            aria-label="Delete Group"
                                         >
                                             <Trash2 className="w-5 h-5" />
                                         </button>

--- a/frontend/src/components/ui/CollapsibleSection.jsx
+++ b/frontend/src/components/ui/CollapsibleSection.jsx
@@ -6,6 +6,7 @@ export const CollapsibleSection = ({ title, description, icon, isOpen, onToggle,
         <div className="bg-card border border-border rounded-xl overflow-hidden transition-all duration-300 shadow-sm hover:shadow-md">
             <button
                 onClick={() => onToggle(id)}
+                aria-expanded={isOpen}
                 className={`w-full flex items-center justify-between p-4 sm:p-6 text-left transition-colors duration-200 ${isOpen ? 'bg-muted/30' : 'hover:bg-muted/10'}`}
             >
                 <div className="flex items-center space-x-4 min-w-0 flex-1 mr-2">


### PR DESCRIPTION
**💡 What:** Added `aria-expanded` to the `CollapsibleSection` toggle button, and added `aria-label`s to the "Edit Group" and "Delete Group" icon-only buttons in the `GroupsManager`.

**🎯 Why:** Screen readers need these explicit ARIA attributes to announce state (like a section being expanded or collapsed) or the purpose of a button when it doesn't contain text content. This makes the interface more accessible for users navigating with keyboards or screen readers.

**♿ Accessibility:**
- `aria-expanded` dynamically updates screen readers on whether the `CollapsibleSection` is currently open or closed.
- `aria-label`s explicitly name the Edit and Delete buttons in the GroupsManager, which previously only had `title` attributes (which are not reliably read by all screen readers).

---
*PR created automatically by Jules for task [18385417807265203987](https://jules.google.com/task/18385417807265203987) started by @spupuz*