### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons in GroupsManager

### DIFF
--- a/frontend/src/components/GroupsManager.jsx
+++ b/frontend/src/components/GroupsManager.jsx
@@ -353,6 +353,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                             onClick={() => openManageModal(group)}
                                             className="p-2 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/40 rounded-lg transition-colors"
                                             title="Edit Group"
+                                            aria-label="Edit Group"
                                         >
                                             <Edit className="w-5 h-5" />
                                         </button>
@@ -360,6 +361,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                             onClick={() => handleDeleteGroup(group.id)}
                                             className="p-2 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40 rounded-lg transition-colors"
                                             title="Delete Group"
+                                            aria-label="Delete Group"
                                         >
                                             <Trash2 className="w-5 h-5" />
                                         </button>


### PR DESCRIPTION
This PR adds `aria-label` attributes to icon-only buttons ("Edit Group" and "Delete Group") in the `GroupsManager.jsx` component. This is a small micro-UX enhancement aimed at improving accessibility for screen readers.

### 💡 What:
Added `aria-label` attributes corresponding to the existing `title` values for the edit and delete icon buttons.

### 🎯 Why:
Icon-only buttons without accessible labels are invisible to screen readers, degrading the user experience for visually impaired users. This ensures parity between visual functionality and semantic accessibility.

### ♿ Accessibility:
- Added `aria-label="Edit Group"` to the edit button.
- Added `aria-label="Delete Group"` to the delete button.

---
*PR created automatically by Jules for task [1057336261985530697](https://jules.google.com/task/1057336261985530697) started by @spupuz*