### PR TITLE
🎨 Palette: Add semantic ARIA attributes to custom toggle switches

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -705,6 +705,9 @@ export const Dashboard = () => {
                                 <div key={key} className="flex items-center justify-between p-2 hover:bg-muted/50 rounded-lg">
                                     <span className="text-sm font-medium">{label}</span>
                                     <button
+                                        role="switch"
+                                        aria-checked={visibleWidgets[key] || false}
+                                        aria-label={label}
                                         onClick={() => setVisibleWidgets(prev => ({ ...prev, [key]: !prev[key] }))}
                                         className={'relative inline-flex h-6 w-11 items-center rounded-full transition-colors ' +
                                             (visibleWidgets[key] ? 'bg-primary' : 'bg-muted')

--- a/frontend/src/pages/Settings/EditUserModal.jsx
+++ b/frontend/src/pages/Settings/EditUserModal.jsx
@@ -68,6 +68,9 @@ export const EditUserModal = ({
                                     <div className="flex items-center gap-3">
                                         <button
                                             type="button"
+                                            role="switch"
+                                            aria-checked={editingUser.restrict_camera_access || false}
+                                            aria-label={t('timeline.restrict_camera_access', 'Restrict Camera Access')}
                                             onClick={() => setEditingUser({ ...editingUser, restrict_camera_access: !editingUser.restrict_camera_access })}
                                             className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${editingUser.restrict_camera_access ? 'bg-primary' : 'bg-muted'}`}
                                         >

--- a/frontend/src/pages/Settings/sections/UserManager.jsx
+++ b/frontend/src/pages/Settings/sections/UserManager.jsx
@@ -95,6 +95,9 @@ export const UserManager = ({
                                 <div className="flex items-center gap-3">
                                     <button
                                         type="button"
+                                        role="switch"
+                                        aria-checked={newUser.restrict_camera_access || false}
+                                        aria-label={t('timeline.restrict_camera_access', 'Restrict Camera Access')}
                                         onClick={() => setNewUser({ ...newUser, restrict_camera_access: !newUser.restrict_camera_access })}
                                         className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${newUser.restrict_camera_access ? 'bg-primary' : 'bg-muted'}`}
                                     >


### PR DESCRIPTION
This pull request improves the accessibility of custom toggle components across the application. Specifically, it updates the "Dashboard Widgets" toggles and the "Restrict Camera Access" toggles in the User Management and Edit User modals.

By adding `role="switch"`, `aria-checked`, and `aria-label` attributes to these `<button>` elements, we ensure that screen reader users are correctly informed about the purpose of the control (a switch) and its current state (on/off).

**Changes made:**
- `src/pages/Dashboard.jsx`: Added ARIA attributes to widget visibility toggles.
- `src/pages/Settings/sections/UserManager.jsx`: Added ARIA attributes to the restrict camera access toggle when creating a user.
- `src/pages/Settings/EditUserModal.jsx`: Added ARIA attributes to the restrict camera access toggle when editing an existing user.

This change aligns with standard Web Content Accessibility Guidelines (WCAG) for custom form controls.

---
*PR created automatically by Jules for task [15713139215926651410](https://jules.google.com/task/15713139215926651410) started by @spupuz*