### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent argument injection in ffprobe subprocess calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The application was missing basic defense-in-depth security headers (like X-Frame-Options: DENY, Strict-Transport-Security, X-Content-Type-Options: nosniff, and X-XSS-Protection) on its HTTP responses.
 **Learning:** By default, FastAPI/Starlette does not inject these standard security headers. Since the app might be exposed directly or via proxies that don't enforce them, it's essential to add them at the application level.
 **Prevention:** A custom middleware `add_security_headers` should be added to the `FastAPI` instance to ensure all responses globally get these headers without having to configure a reverse proxy.
+
+## 2024-05-24 - Prevent Argument Injection in Subprocess Calls
+**Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
+**Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
+**Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.

--- a/backend/migrate_and_sync.py
+++ b/backend/migrate_and_sync.py
@@ -32,7 +32,7 @@ def get_video_duration(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5)
         if result.returncode == 0:

--- a/backend/probe_service.py
+++ b/backend/probe_service.py
@@ -37,14 +37,14 @@ def probe_stream(rtsp_url: str, rtsp_transport: str = "tcp"):
         "-show_streams",
         "-select_streams", "v:0",  # Select first video stream
         "-rtsp_transport", rtsp_transport,  # Use configured transport
-        rtsp_url
+        "-i", rtsp_url
     ]
 
     # Secure RTSP (RSTSPS/RTSPS) - Skip verification (common for self-signed NVRs)
     if rtsp_url.lower().startswith(('rstsps://', 'rtsps://')):
-        # Insert before the URL (last arg)
-        cmd.insert(-1, "-tls_verify")
-        cmd.insert(-1, "0")
+        # Insert before the -i flag (second to last arg)
+        cmd.insert(-2, "-tls_verify")
+        cmd.insert(-2, "0")
         logger.info(f"Probing secure stream, skipping TLS verification for {mask_url(rtsp_url)}")
 
     # Security: Ensure URL doesn't start with - to prevent flag injection

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -686,7 +686,7 @@ def process_webhook_file_event(camera_id: int, event_type: str, payload: dict, i
                     try:
                         cmd = [
                             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-                            "-of", "default=noprint_wrappers=1:nokey=1", local_path
+                            "-of", "default=noprint_wrappers=1:nokey=1", "-i", local_path
                         ]
                         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
                         if result.returncode == 0:

--- a/backend/sync_recordings.py
+++ b/backend/sync_recordings.py
@@ -37,7 +37,7 @@ def get_video_duration(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
         if result.returncode == 0:
@@ -69,7 +69,7 @@ def is_video_valid(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
         if result.returncode != 0:


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Dynamic external input (URLs, file paths) passed directly to `ffprobe` subprocess calls without explicitly preceding them with the `-i` flag can be misinterpreted as arbitrary command-line flags if they start with `-`, leading to argument/command injection.
🎯 **Impact**: Maliciously crafted user inputs could be injected as flags to arbitrary tools executed via subprocess, leading to potential execution of unintended code or DoS on the backend processor.
🔧 **Fix**: Enforced the strict use of the `-i` flag immediately preceding any dynamic input URL or file path passed to `ffprobe` across `migrate_and_sync.py`, `probe_service.py`, `routers/events.py`, and `sync_recordings.py`. Added corresponding documentation in `.jules/sentinel.md`.
✅ **Verification**: Code linters run with `ruff check` and internal CI test suites verified locally with `pytest`.

---
*PR created automatically by Jules for task [6440521353860242492](https://jules.google.com/task/6440521353860242492) started by @spupuz*