### PR TITLE
⚡ Bolt: Fix N+1 query in bulk delete events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-02-12 - [Optimize get_detailed_storage_stats API with group_by]
 **Learning:** To resolve SQLAlchemy N+1 query lazy loading or iterative loop issues when performing aggregations (e.g., getting counts or sizes per element from an event table), prefer utilizing SQL `GROUP BY` logic directly in the query (e.g., `db.query(..., func.count()).group_by(...)`) rather than querying the database repeatedly in a loop for each entity.
 **Action:** Always look for O(N) aggregate database querying in backend code and refactor it into a single O(1) query with `group_by`.
+## 2025-01-24 - N+1 query in bulk deletion
+**Learning:** In backend endpoints processing a list of items for bulk action (e.g. `bulk_delete_events`), querying the database for each item individually inside a `for` loop causes an N+1 query issue, severely hurting performance.
+**Action:** Use an `.in_()` filter (e.g., `db.query(Model).filter(Model.id.in_(ids)).all()`) to pre-fetch all records in a single query and process them via an in-memory dictionary map, reducing database lookups from O(N) to O(1).

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -811,8 +811,12 @@ def bulk_delete_events(request: schemas.BulkDeleteRequest, db: Session = Depends
     deleted_count = 0
     errors = []
 
+    # ⚡ Bolt: Fetch all events in a single O(1) query instead of O(N) queries inside the loop
+    events = db.query(models.Event).filter(models.Event.id.in_(request.event_ids)).all()
+    events_map = {event.id: event for event in events}
+
     for event_id in request.event_ids:
-        event = db.query(models.Event).filter(models.Event.id == event_id).first()
+        event = events_map.get(event_id)
         if not event:
             errors.append(f"Event {event_id} not found")
             continue


### PR DESCRIPTION
💡 What: Refactored the `bulk_delete_events` API endpoint to use an `.in_()` filter to fetch all events at once instead of querying them sequentially inside a for loop.
🎯 Why: The previous implementation queried the database for each event ID iteratively, resulting in an O(N) query bottleneck which hurt performance during bulk operations.
📊 Impact: Expected performance improvement is significant for large bulk delete actions, reducing database roundtrips from O(N) to O(1).
🔬 Measurement: Verify by executing a bulk delete request with multiple IDs and observing reduced database query logs/latency.

---
*PR created automatically by Jules for task [8380447667170952407](https://jules.google.com/task/8380447667170952407) started by @spupuz*