### PR TITLE
⚡ Bolt: Resolving N+1 query issue for Camera Groups serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2025-02-12 - [Optimize get_detailed_storage_stats API with group_by]
 **Learning:** To resolve SQLAlchemy N+1 query lazy loading or iterative loop issues when performing aggregations (e.g., getting counts or sizes per element from an event table), prefer utilizing SQL `GROUP BY` logic directly in the query (e.g., `db.query(..., func.count()).group_by(...)`) rather than querying the database repeatedly in a loop for each entity.
 **Action:** Always look for O(N) aggregate database querying in backend code and refactor it into a single O(1) query with `group_by`.
+
+## 2024-05-18 - Chained selectinload for deeply nested Pydantic serialization
+**Learning:** When serializing SQLAlchemy models with Pydantic (e.g., via `model_validate`), accessing nested relationships defined in the Pydantic schema will silently trigger N+1 database queries. For instance, serializing `CameraGroup` fetches its `cameras`, and then fetches each camera's `groups` and `storage_profile`.
+**Action:** Always pre-load deeply nested relationships using chained `selectinload` (e.g., `selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups)`) in the initial SQLAlchemy query to prevent Cartesian explosion and O(N) queries during API response generation.

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -254,7 +254,13 @@ def update_user_password(db: Session, user_id: int, hashed_password: str):
 
 # Groups
 def get_groups(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(models.CameraGroup).offset(skip).limit(limit).all()
+    # ⚡ Bolt: Resolving N+1 query issue during serialization.
+    # When Pydantic serializes groups, it fetches the cameras, which in turn fetch their nested groups and storage profiles.
+    # Using chained selectinload pre-fetches all these relationships in constant O(1) queries instead of O(N) queries.
+    return db.query(models.CameraGroup).options(
+        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
+        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.storage_profile)
+    ).offset(skip).limit(limit).all()
 
 def get_group(db: Session, group_id: int):
     return db.query(models.CameraGroup).filter(models.CameraGroup.id == group_id).first()


### PR DESCRIPTION
💡 What: Modified `get_groups` in `backend/crud.py` to use chained `selectinload` for `CameraGroup.cameras` and their nested `groups` and `storage_profile` relationships.
🎯 Why: Pydantic serialization of the groups API endpoint triggered an N+1 query problem, making a DB query for every camera in every group when resolving deeply nested fields. 
📊 Impact: Reduces O(N) database queries during the `/api/groups` endpoint serialization down to a constant O(1) number of queries. This significantly speeds up API response times for installations with many groups and cameras.
🔬 Measurement: Verified using an in-memory test bench script to count emitted SQLAlchemy `SELECT` statements (which went from a dynamic number based on groups/cameras down to 3 static queries). Verified safety with existing `pytest .github/scripts/test_crud.py` suite.

---
*PR created automatically by Jules for task [3647970197968390786](https://jules.google.com/task/3647970197968390786) started by @spupuz*