### PR TITLE
fix(engine): keep AI detection alive when global config desyncs (silent system-wide outage)

### DIFF
--- a/engine/ai_detector.py
+++ b/engine/ai_detector.py
@@ -106,6 +106,41 @@ class AIDetector:
         self.inference_count = 0
         self.last_inference_attempt = 0
         self._is_loading = False
+        self._start_staleness_watchdog()
+
+    def _start_staleness_watchdog(self):
+        """Independent alarm/backstop for AI going silently dead.
+
+        The existing reload path only triggers on an invoke() timeout (None
+        interpreter). But AI can also stop silently with the interpreter still
+        fine — e.g. detect() stops being called upstream. This thread watches
+        last_inference_attempt (set on the first line of detect()) and logs the
+        moment it goes stale while AI is enabled, so the cause is captured live
+        instead of discovered hours later. As a backstop it reloads the model if
+        the interpreter itself is gone.
+        """
+        def _wd():
+            last_reload = 0.0
+            while True:
+                time.sleep(15)
+                try:
+                    if not self._enabled or not self.last_inference_attempt:
+                        continue
+                    age = time.time() - self.last_inference_attempt
+                    if age > 60:
+                        logger.error(
+                            f"[AI-WD] detect() not called for {age:.0f}s while AI enabled "
+                            f"(count={self.inference_count}, interp={'ok' if self.interpreter else 'None'}, "
+                            f"hw={self.hardware}, loading={self._is_loading}) — inference pipeline starved"
+                        )
+                        if self.interpreter is None and not self._is_loading and time.time() - last_reload > 60:
+                            last_reload = time.time()
+                            logger.error("[AI-WD] interpreter is None — triggering model reload")
+                            threading.Thread(target=self._load_model, daemon=True).start()
+                except Exception as e:
+                    logger.error(f"[AI-WD] watchdog error: {e}")
+        threading.Thread(target=_wd, daemon=True).start()
+        logger.info("AI: staleness watchdog started")
 
     @property
     def enabled(self):

--- a/engine/camera_thread.py
+++ b/engine/camera_thread.py
@@ -124,6 +124,43 @@ class CameraThread(threading.Thread):
     def get_health(self):
         return self.stream_reader.get_health()
 
+    def _stream_health_watchdog(self):
+        """Detect + recover silently-stalled stream readers.
+
+        A reader only self-reconnects on a decode *exception*. A valid-but-
+        undecodable stream (e.g. an SPS/PPS mismatch from a flaky proxy or a
+        lossy VPN link) keeps connected=True while decode yields no frames and
+        no exception fires — latest_frame freezes forever, the camera silently
+        stops feeding AI/motion, and only a full engine restart clears it. We
+        catch that here: a connected reader whose last decoded frame is older
+        than STALL_SECS is forced to reconnect. Each check also logs a state
+        snapshot so a stall vs a reconnect-loop can be told apart from logs.
+        """
+        STALL_SECS = 30.0
+        now = time.time()
+        for tag, r in (("primary", self.stream_reader), ("sub", self.sub_stream_reader)):
+            if r is None:
+                continue
+            lrt = getattr(r, 'last_read_time', 0) or 0
+            ct = getattr(r, 'connection_time', 0) or 0
+            age = now - lrt if lrt else -1
+            conn_age = now - ct if ct else -1
+            if r.connected and lrt and age > 10:
+                logger.warning(
+                    f"[STREAM-WD] Cam {self.camera_id} {tag}: health={r.health_status} "
+                    f"connected={r.connected} frame_age={age:.1f}s conn_age={conn_age:.1f}s "
+                    f"fails={getattr(r, 'consecutive_failures', '?')}"
+                )
+            if r.connected and lrt and age > STALL_SECS:
+                logger.error(
+                    f"[STREAM-WD] Cam {self.camera_id} {tag}: STALLED {age:.1f}s with no decoded "
+                    f"frame while connected — forcing reconnect"
+                )
+                try:
+                    r.force_reconnect()
+                except Exception as e:
+                    logger.error(f"[STREAM-WD] Cam {self.camera_id} {tag}: force_reconnect failed: {e}")
+
     def run(self):
         self.running = True
         logger.info(f"Camera {self.config.get('name')} (ID: {self.camera_id}): Starting loop")
@@ -140,6 +177,7 @@ class CameraThread(threading.Thread):
                     last_heartbeat_time = time.time()
                     age = time.time() - self.stream_reader.last_read_time if self.stream_reader.last_read_time else -1
                     logger.debug(f"[HB] Cam {self.camera_id}: health={self.stream_reader.health_status}, recording={self.recording_manager.is_recording}, frame_age={age:.1f}s")
+                    self._stream_health_watchdog()  # recover + diagnose silently-stalled readers
 
                 # Segment Rotation Check (Decoupled from frame decode)
                 if self.recording_manager.check_segment_rotation(self.stop_recording):
@@ -182,8 +220,16 @@ class CameraThread(threading.Thread):
                 
                 detect_engine = self.config.get('detect_engine', 'OpenCV')
                 
-                # Fallback to OpenCV if AI is disabled globally but camera is set to AI
-                if detect_engine == 'AI' and not self.manager.global_config.get('ai_enabled', False):
+                # Fallback to OpenCV if AI is disabled globally but camera is set to AI.
+                # Gate on the AIDetector singleton's own enabled flag, NOT
+                # manager.global_config['ai_enabled']. The latter silently drifts to False
+                # (a manager reinit resets global_config to {}, or a config sync lands
+                # before the ai_enabled key is set) while the detector stays loaded and
+                # enabled — which makes EVERY camera fall back to OpenCV motion and
+                # silently kills AI detection system-wide until an engine restart. The
+                # detector flag is the single source of truth and survives those resets.
+                ai_on = getattr(self.ai_detector, 'enabled', False) or self.manager.global_config.get('ai_enabled', False)
+                if detect_engine == 'AI' and not ai_on:
                     detect_engine = 'OpenCV'
                     
                 # AI Inference Logic


### PR DESCRIPTION
## Problem
AI detection silently stopped on **all cameras at once** and never recovered until a manual engine restart. Nothing in the logs: the interpreter is alive, `/stats` looks fine, logs show "Active Detect Engine: AI", recording keeps running. Meanwhile the `events` table only gets `motion` events with `score=0` and zero AI metadata.

## Root cause
`camera_thread` gated the AI branch on `manager.global_config['ai_enabled']`. That flag drifts to `False` (a manager reinit resets `global_config` to `{}`, or a config sync lands before the key is set) while the `AIDetector` singleton stays loaded with `enabled=True`. Via `.get('ai_enabled', False)` every camera then silently falls back to OpenCV motion and `ai_detector.detect()` is never called.

## Changes
- **Gate fix:** the AI branch now gates on `AIDetector.enabled` (the single source of truth that survives manager resets), not `manager.global_config`.
- **Stream-health watchdog:** force-reconnect a reader that is `connected=True` but has produced no decoded frame for >30s. A valid-but-undecodable stream freezes `latest_frame` with no exception and never self-recovers today.
- **Inference-staleness watchdog:** log loudly when `detect()` hasn't been called for >60s while AI is enabled, and reload the model if the interpreter is gone.

## Testing
Reproduced and fixed on a live instance (remote cameras over a VPN link): before the fix `detect()` went uncalled for 6.5h while frames were fresh; after, detection is stable and survives restarts. Syntax-checked; behaviour is unchanged when the flags are in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
