### PR TITLE
🛡️ Sentinel: [MEDIUM/HIGH] Fix timing attack in webhook secret verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+
+## 2025-02-28 - Prevent Timing Attacks in Webhook Secret Verification
+**Vulnerability:** The application verified incoming webhook secrets using a direct string comparison (`if secret_header != expected_secret:`).
+**Learning:** Standard string equality checks short-circuit and return `False` as soon as a character doesn't match. This allows an attacker to perform a timing attack by measuring the response time, discovering the secret character by character.
+**Prevention:** Always use `hmac.compare_digest(provided_secret, expected_secret)` when comparing security-sensitive strings, API keys, tokens, or hashes to ensure the comparison time is constant, regardless of when a mismatch occurs. Note that `hmac.compare_digest` may require encoding the strings to bytes if comparing unicode.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -14,6 +14,7 @@ import auth_service
 import datetime
 import logging
 import time
+import hmac
 
 logger = logging.getLogger(__name__)
 
@@ -537,7 +538,7 @@ async def webhook_event(
     # Use dedicated WEBHOOK_SECRET if set, otherwise fallback to SECRET_KEY
     expected_secret = os.getenv("WEBHOOK_SECRET", auth_service.SECRET_KEY)
 
-    if secret_header != expected_secret:
+    if not secret_header or not hmac.compare_digest(secret_header.encode('utf-8'), expected_secret.encode('utf-8')):
         # Avoid leaking existence or details, but allow local debugging if needed?
         # Strict security: 401.
         logger.warning("[WEBHOOK] Unauthorized access attempt (Invalid Secret).")


### PR DESCRIPTION
🛡️ Sentinel Security Fix

🚨 **Severity:** MEDIUM/HIGH
💡 **Vulnerability:** The application verified incoming webhook secrets using a direct string comparison (`if secret_header != expected_secret:`). Standard string equality checks short-circuit and return `False` as soon as a character doesn't match, making the endpoint vulnerable to timing attacks.
🎯 **Impact:** An attacker could potentially figure out the webhook secret byte by byte by measuring the response time of the webhook endpoint.
🔧 **Fix:** Replaced the direct string comparison with `hmac.compare_digest(secret_header.encode('utf-8'), expected_secret.encode('utf-8'))` to ensure a constant-time comparison, mitigating the timing attack vulnerability.
✅ **Verification:** Ran `ruff` for linting and passed all existing `pytest` tests locally. Also added the finding to the Sentinel journal.

---
*PR created automatically by Jules for task [4509319324223870928](https://jules.google.com/task/4509319324223870928) started by @spupuz*