### PR TITLE
🎨 Palette: Add aria-label to active hour filter button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-06-27 - [Add ARIA labels to icon-only buttons]
 **Learning:** When making UX accessibility improvements, avoid the anti-pattern of adding an `aria-label` that is exactly identical to the visible text content of an interactive element (e.g., a button), as screen readers natively announce text content, and duplicate labels cause redundant announcements. However, for buttons that only have an icon, or text that might be hidden or visually truncated, `aria-label`s are still necessary.
 **Action:** Add `aria-label` attributes to icon-only buttons for better screen reader accessibility.
+## 2024-05-24 - Add ARIA label to active hour filter button
+**Learning:** When clearing active hour filters, the button relies solely on visual text ("{hour}:00 ✕"). Screen readers miss the context of the action being a filter clear operation without an explicit `aria-label`.
+**Action:** Always add an `aria-label` to custom filter clearing buttons, especially those using symbols like "✕", to clearly indicate their function to screen readers.

--- a/frontend/src/components/Timeline/EventFilters.jsx
+++ b/frontend/src/components/Timeline/EventFilters.jsx
@@ -160,6 +160,7 @@ export const EventFilters = ({
                 <button
                     onClick={() => setSelectedHour(null)}
                     className="px-3 py-2 text-sm bg-red-500/10 text-red-500 border border-red-500/20 rounded-xl hover:bg-red-500/20 transition-colors flex items-center gap-1.5"
+                    aria-label={`Clear hour filter for ${selectedHour}:00`}
                 >
                     <span className="font-bold">{selectedHour}:00</span>
                     <span className="opacity-70">✕</span>


### PR DESCRIPTION
Added an `aria-label` to the active hour filter clearing button in `EventFilters.jsx` to improve accessibility for screen readers. Previously, the button only contained visual text (e.g., "14:00 ✕"), which lacked context. The new label provides a clear description of the button's action. Also documented this learning in the UX journal.

---
*PR created automatically by Jules for task [11274334334640771450](https://jules.google.com/task/11274334334640771450) started by @spupuz*