### PR TITLE
⚡ Replace blocking time.sleep with asyncio.sleep in app startup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,4 @@
 ## 2025-02-12 - [Optimize _generate_backup_data API with selectinload]
 **Learning:** In APIs dealing with large exports (like generating full backup dictionaries of the entire database state), accessing lazy-loaded relationships during JSON serialization can trigger thousands of O(N) queries, significantly degrading performance.
 **Action:** Always eagerly load relationships using `selectinload` (e.g. `.options(selectinload(Model.relation))`) on bulk API queries that serialize nested components, particularly when assembling large data structures like backups.
+- When refactoring blocking calls (e.g., `time.sleep`) to async equivalents (e.g., `asyncio.sleep`) in FastAPI lifespan or other async contexts, carefully check for nested synchronous functions or background threads (like `run_orphan_recovery`) in the same file that still rely on the original synchronous module before removing their imports.

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ import os
 import logging
 import json
 
+import asyncio
 import io
 import re
 import threading
@@ -256,7 +257,7 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             retry_count += 1
             logger.info(f"Waiting for Database (Attempt {retry_count})...")
-            time.sleep(2)
+            await asyncio.sleep(2)
 
     # Start background tasks
     storage_service.start_scheduler()


### PR DESCRIPTION
💡 **What:** Replaced the blocking `time.sleep(2)` call with the non-blocking `await asyncio.sleep(2)` inside the main `lifespan` function during FastAPI startup database polling.
🎯 **Why:** `time.sleep` blocks the entire main thread where the event loop resides, which prevents other scheduled asynchronous tasks from executing and can cause the FastAPI application to become unresponsive until the database finally connects.
📊 **Measured Improvement:** While it is difficult to show a standard metric (like requests per second) for this change as it happens during application startup, replacing synchronous blocking sleep in an asynchronous event loop is a foundational async best practice. By releasing the event loop, background async jobs or other setup procedures can progress concurrently while waiting for the database to be reachable, improving overall boot robustness and responsiveness.

---
*PR created automatically by Jules for task [9849856530623750625](https://jules.google.com/task/9849856530623750625) started by @spupuz*