### PR TITLE
🎨 Palette: Enhance Timeline Filter Accessibility

### DIFF
--- a/frontend/src/components/Timeline/EventFilters.jsx
+++ b/frontend/src/components/Timeline/EventFilters.jsx
@@ -151,6 +151,7 @@ export const EventFilters = ({
                         ? 'bg-primary/10 border-primary/20 text-primary font-medium'
                         : 'bg-card border-border hover:bg-accent text-muted-foreground'
                     }`}
+                aria-label={t('timeline.reset', 'Reset')}
             >
                 <span>{t('timeline.reset', 'Reset')}</span>
             </button>
@@ -160,6 +161,8 @@ export const EventFilters = ({
                 <button
                     onClick={() => setSelectedHour(null)}
                     className="px-3 py-2 text-sm bg-red-500/10 text-red-500 border border-red-500/20 rounded-xl hover:bg-red-500/20 transition-colors flex items-center gap-1.5"
+                    title={t('timeline.clear_hour_filter', 'Clear hour filter')}
+                    aria-label={t('timeline.clear_hour_filter', 'Clear hour filter')}
                 >
                     <span className="font-bold">{selectedHour}:00</span>
                     <span className="opacity-70">✕</span>


### PR DESCRIPTION
### 💡 What
Added semantic `aria-label` and `title` attributes to icon-only action buttons within the Timeline's Event Filters component.

### 🎯 Why
Icon-only buttons, particularly the active hour filter's "✕" cancel button, are opaque to assistive technologies like screen readers, which would previously just read "14:00 X". Adding specific `aria-label`s ensures these actions are fully accessible, while adding `title`s provides helpful tooltips for sighted users.

### ♿ Accessibility
- Added `aria-label` to the 'Reset' button.
- Added `aria-label` and `title` to the active hour cancel button to clarify its destructive action.

---
*PR created automatically by Jules for task [8937397850828207421](https://jules.google.com/task/8937397850828207421) started by @spupuz*