### PR TITLE
⚡ Bolt: Optimize camera count queries in homepage stats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2025-02-12 - [Optimize _generate_backup_data API with selectinload]
 **Learning:** In APIs dealing with large exports (like generating full backup dictionaries of the entire database state), accessing lazy-loaded relationships during JSON serialization can trigger thousands of O(N) queries, significantly degrading performance.
 **Action:** Always eagerly load relationships using `selectinload` (e.g. `.options(selectinload(Model.relation))`) on bulk API queries that serialize nested components, particularly when assembling large data structures like backups.
+## 2025-02-12 - [Optimize homepage stats with DB aggregation]
+**Learning:** In dashboards or stats endpoints that simply need counts or filtered counts of rows, loading all SQLAlchemy ORM objects into memory (e.g., `db.query(Model).all()`) to run `len()` is an O(N) memory anti-pattern. Using native database aggregations like `db.query(func.count(Model.id)).scalar()` converts this into an efficient O(1) query.
+**Action:** Always refactor Python-level `len(items)` on bulk ORM fetches into direct SQL `COUNT` aggregations to preserve memory and speed up response times.

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -23,9 +23,9 @@ def get_homepage_stats(
     Requires authentication via API token (X-API-Key header).
     """
     # Camera Stats
-    cameras = db.query(models.Camera).all()
-    cameras_total = len(cameras)
-    cameras_online = len([c for c in cameras if c.is_active])
+    # ⚡ Bolt: Use DB aggregation (O(1)) instead of loading all objects into memory (O(N))
+    cameras_total = db.query(func.count(models.Camera.id)).scalar() or 0
+    cameras_online = db.query(func.count(models.Camera.id)).filter(models.Camera.is_active.is_(True)).scalar() or 0
     
     # Active Recording Cameras (using LIVE_MOTION / ACTIVE_CAMERAS from events router)
     # ACTIVE_CAMERAS tracks ongoing motion events


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced Python-level O(N) memory len() calculations on full database objects fetches with O(1) database-level `COUNT` aggregations using `func.count()`.

🎯 Why: The performance problem it solves
In `backend/routers/homepage.py`'s `get_homepage_stats`, all camera objects were being pulled into Python memory (`db.query(models.Camera).all()`) solely to count the total cameras and the active cameras. This created an N+1 query-like bottleneck in memory mapping, causing the endpoint to scale poorly with large numbers of cameras. 

📊 Impact: Expected performance improvement
Reduces endpoint memory consumption from O(N) to O(1) and eliminates object initialization overhead entirely. Speeds up dashboard load times for users with many cameras.

🔬 Measurement: How to verify the improvement
Verified correctness locally with `pytest` and `ruff check`. Measurement can be verified via network trace response times on `/homepage/stats` with a large camera database.

---
*PR created automatically by Jules for task [9336706605994660289](https://jules.google.com/task/9336706605994660289) started by @spupuz*