### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in webhook validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+
+## 2025-05-30 - Prevent Timing Attacks in Webhook Secret Validation
+**Vulnerability:** The `webhook_event` endpoint compared the `X-Webhook-Secret` using standard string equality (`!=`), which is vulnerable to timing attacks.
+**Learning:** Standard string comparisons can fail early on the first mismatched character, allowing attackers to incrementally guess the secret based on response times.
+**Prevention:** Always use `hmac.compare_digest` for security-sensitive string comparisons like API keys, tokens, or webhook secrets. Ensure inputs are encoded to bytes if comparing unicode strings.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -14,6 +14,7 @@ import auth_service
 import datetime
 import logging
 import time
+import hmac
 
 logger = logging.getLogger(__name__)
 
@@ -537,7 +538,7 @@ async def webhook_event(
     # Use dedicated WEBHOOK_SECRET if set, otherwise fallback to SECRET_KEY
     expected_secret = os.getenv("WEBHOOK_SECRET", auth_service.SECRET_KEY)
 
-    if secret_header != expected_secret:
+    if not secret_header or not hmac.compare_digest(secret_header.encode('utf-8'), expected_secret.encode('utf-8')):
         # Avoid leaking existence or details, but allow local debugging if needed?
         # Strict security: 401.
         logger.warning("[WEBHOOK] Unauthorized access attempt (Invalid Secret).")


### PR DESCRIPTION
Replaced vulnerable standard string equality (`!=`) with `hmac.compare_digest` in `backend/routers/events.py` for verifying the `X-Webhook-Secret` header. This mitigates the risk of an attacker incrementally guessing the webhook secret. Also documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16940516594800600434](https://jules.google.com/task/16940516594800600434) started by @spupuz*