### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Timing Attack in Webhook Verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+
+## 2026-07-06 - Secure String Comparison for Webhook Secrets
+**Vulnerability:** Timing attack vulnerability in webhook secret verification (in `backend/routers/events.py`) due to the use of standard equality operators (`!=`) for comparing security-sensitive strings.
+**Learning:** Using standard equality operators for cryptographic secrets allows attackers to measure the time it takes for the comparison to fail, potentially brute-forcing the secret byte by byte.
+**Prevention:** Always use `hmac.compare_digest(provided, expected)` when comparing security-sensitive strings (e.g., API keys, tokens, webhooks) to prevent timing attacks. Ensure the strings are encoded to bytes if they are unicode.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -11,6 +11,7 @@ import threading
 import models
 import subprocess
 import auth_service
+import hmac
 import datetime
 import logging
 import time
@@ -537,7 +538,7 @@ async def webhook_event(
     # Use dedicated WEBHOOK_SECRET if set, otherwise fallback to SECRET_KEY
     expected_secret = os.getenv("WEBHOOK_SECRET", auth_service.SECRET_KEY)
 
-    if secret_header != expected_secret:
+    if not secret_header or not hmac.compare_digest(secret_header.encode('utf-8'), expected_secret.encode('utf-8')):
         # Avoid leaking existence or details, but allow local debugging if needed?
         # Strict security: 401.
         logger.warning("[WEBHOOK] Unauthorized access attempt (Invalid Secret).")


### PR DESCRIPTION
Replaced standard string equality comparison with hmac.compare_digest in backend/routers/events.py to prevent timing attacks when comparing security-sensitive webhook secrets. Also added a journal entry documenting this fix.

---
*PR created automatically by Jules for task [8969314500161059887](https://jules.google.com/task/8969314500161059887) started by @spupuz*