### PR TITLE
🧪 [testing improvement] Add tests for get_cameras eager loading and pagination

### DIFF
--- a/.github/scripts/test_crud.py
+++ b/.github/scripts/test_crud.py
@@ -264,3 +264,97 @@ def test_create_camera_string_ai_object_types(mock_camera):
     mock_camera.assert_called_once_with(**camera_data)
     db_mock.add.assert_called_once()
     db_mock.commit.assert_called_once()
+
+def test_get_cameras_eager_loading_and_sorting(db):
+    from models import Camera, CameraGroup, StorageProfile
+    import crud
+
+    # Create a storage profile
+    sp = StorageProfile(name="Main Storage", path="/mnt/data")
+    db.add(sp)
+    db.commit()
+    db.refresh(sp)
+
+    # Create groups
+    g1 = CameraGroup(name="Group 1")
+    g2 = CameraGroup(name="Group 2")
+    db.add_all([g1, g2])
+    db.commit()
+    db.refresh(g1)
+    db.refresh(g2)
+
+    # Create cameras with specific sort_order
+    c1 = Camera(name="Cam B", rtsp_url="rtsp://b", sort_order=2, storage_profile_id=sp.id)
+    c2 = Camera(name="Cam A", rtsp_url="rtsp://a", sort_order=1) # No storage profile
+    c3 = Camera(name="Cam C", rtsp_url="rtsp://c", sort_order=1) # Same sort_order, higher id (inserted later)
+    db.add_all([c1, c2, c3])
+    db.commit()
+    db.refresh(c1)
+    db.refresh(c2)
+    db.refresh(c3)
+
+    # Associate groups
+    c1.groups.append(g1)
+    c2.groups.extend([g1, g2])
+    db.commit()
+
+    # Clear the session so we are forced to load from DB
+    db.expunge_all()
+
+    # Test get_cameras with default skip=0, limit=100
+    cameras = crud.get_cameras(db)
+
+    # Check sorting: sort_order ASC, id ASC
+    # c2 and c3 have sort_order=1. Since c2 was added first, c2.id < c3.id
+    # c1 has sort_order=2
+    assert len(cameras) >= 3
+    test_cams = [c for c in cameras if c.name in ("Cam A", "Cam B", "Cam C")]
+    assert len(test_cams) == 3
+    assert test_cams[0].name == "Cam A" # c2
+    assert test_cams[1].name == "Cam C" # c3
+    assert test_cams[2].name == "Cam B" # c1
+
+    # Check eager loading by expunging from session and checking attributes
+    db.expunge_all()
+
+    cam_a = next(c for c in test_cams if c.name == "Cam A")
+    cam_b = next(c for c in test_cams if c.name == "Cam B")
+    cam_c = next(c for c in test_cams if c.name == "Cam C")
+
+    # These should not raise detached instance errors because of selectinload
+    assert len(cam_a.groups) == 2
+    assert {g.name for g in cam_a.groups} == {"Group 1", "Group 2"}
+    assert cam_a.storage_profile is None
+
+    assert len(cam_b.groups) == 1
+    assert cam_b.groups[0].name == "Group 1"
+    assert cam_b.storage_profile is not None
+    assert cam_b.storage_profile.name == "Main Storage"
+
+    assert len(cam_c.groups) == 0
+    assert cam_c.storage_profile is None
+
+def test_get_cameras_pagination(db):
+    from models import Camera
+    import crud
+
+    # Create 5 cameras
+    cams = [Camera(name=f"Cam P{i}", rtsp_url=f"rtsp://p{i}", sort_order=i) for i in range(5)]
+    db.add_all(cams)
+    db.commit()
+
+    # Test skip and limit
+    all_cams = crud.get_cameras(db)
+    total = len(all_cams)
+
+    assert total >= 5
+
+    res1 = crud.get_cameras(db, skip=0, limit=2)
+    assert len(res1) == 2
+    assert res1[0].id == all_cams[0].id
+    assert res1[1].id == all_cams[1].id
+
+    res2 = crud.get_cameras(db, skip=2, limit=2)
+    assert len(res2) == 2
+    assert res2[0].id == all_cams[2].id
+    assert res2[1].id == all_cams[3].id


### PR DESCRIPTION
🎯 **What:** Missing tests for the `get_cameras` CRUD operation, specifically around testing the eager loading (`selectinload`) functionality and pagination.
📊 **Coverage:** The tests now verify that relationships are eagerly loaded (by deliberately expunging the objects from the session and then checking properties), and it also validates proper `skip` and `limit` pagination, and default sorting options.
✨ **Result:** Better test reliability and prevention of regressions if eager-loading or pagination logic gets refactored.

---
*PR created automatically by Jules for task [13502197115049442148](https://jules.google.com/task/13502197115049442148) started by @spupuz*