### PR TITLE
🎨 Palette: Add aria-labels to icon-only control buttons

### DIFF
--- a/frontend/src/components/ApiTokenManager.jsx
+++ b/frontend/src/components/ApiTokenManager.jsx
@@ -155,7 +155,7 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                             </p>
                             <div className="flex items-center gap-2 mt-3 bg-background p-2 rounded border border-border">
                                 <code className="flex-1 font-mono text-sm break-all">{createdToken.token}</code>
-                                <Button size="sm" variant="ghost" onClick={() => copyToClipboard(createdToken.token)}>
+                                <Button size="sm" variant="ghost" title="Copy" aria-label="Copy" onClick={() => copyToClipboard(createdToken.token)}>
                                     <Copy className="w-4 h-4" />
                                 </Button>
                             </div>

--- a/frontend/src/pages/Logs.jsx
+++ b/frontend/src/pages/Logs.jsx
@@ -178,6 +178,7 @@ export const Logs = () => {
                         onClick={() => setAutoScroll(!autoScroll)}
                         className={`p-2 rounded-md border transition-colors ${autoScroll ? 'bg-primary/10 border-primary/20 text-primary' : 'bg-background border-border text-muted-foreground'}`}
                         title={autoScroll ? t('logs.pause_scroll', 'Pause Auto-scroll') : t('logs.resume_scroll', 'Resume Auto-scroll')}
+                        aria-label={autoScroll ? t('logs.pause_scroll', 'Pause Auto-scroll') : t('logs.resume_scroll', 'Resume Auto-scroll')}
                     >
                         {autoScroll ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
                     </button>
@@ -185,13 +186,15 @@ export const Logs = () => {
                         onClick={fetchLogs}
                         className="p-2 rounded-md hover:bg-accent text-muted-foreground"
                         title={t('logs.refresh_now', 'Refresh Now')}
+                        aria-label={t('logs.refresh_now', 'Refresh Now')}
                     >
                         <RefreshCw className="w-4 h-4" />
                     </button>
                     <button
                         onClick={() => setShowSettings(true)}
                         className="p-2 rounded-md hover:bg-accent text-muted-foreground"
-                        title="Log Settings"
+                        title={t('logs.log_rotation_settings', 'Log Rotation Settings')}
+                        aria-label={t('logs.log_rotation_settings', 'Log Rotation Settings')}
                     >
                         <SettingsIcon className="w-4 h-4" />
                     </button>


### PR DESCRIPTION
💡 What
Added missing `aria-label` and `title` attributes to icon-only control buttons across two components: the "Copy" button in `ApiTokenManager` and the "Pause/Resume", "Refresh", and "Settings" buttons on the `Logs` page.

🎯 Why
These buttons previously consisted entirely of Lucide icons without any text content or ARIA descriptions, making them invisible or confusing to screen reader users, which is an accessibility violation. Adding titles also provides helpful hover tooltips for mouse users, clarifying the function of each button.

📸 Before/After
- Before: `<button><Copy /></button>`
- After: `<button title="Copy" aria-label="Copy"><Copy /></button>`

♿ Accessibility
- Improves WCAG compliance for interactive elements by ensuring all icon-only buttons have accessible names.
- Screen readers will now correctly announce the purpose of the API Token copy button and the Logs page control buttons.

---
*PR created automatically by Jules for task [6886073197625402750](https://jules.google.com/task/6886073197625402750) started by @spupuz*