### PR TITLE
chore(engine): remove FIX prefix from implemented comment

### DIFF
--- a/engine/camera_thread.py
+++ b/engine/camera_thread.py
@@ -273,7 +273,7 @@ class CameraThread(threading.Thread):
                             self.latest_ai_results = ai_results
                             self.last_ai_update_time = time.time()
                             self.last_external_motion_time = self.last_ai_update_time
-                            self.motion_detector.last_motion_time = self.last_ai_update_time  # FIX: Ensure motion state persists
+                            self.motion_detector.last_motion_time = self.last_ai_update_time  # Ensure motion state persists
                             hw_label = f"{self.ai_detector.hardware.upper()} - {self.ai_detector.model_type}"
                             self.last_external_motion_source = f"AI Engine [{hw_label}]"
                             # Sync with motion detector so handle_recording knows it's active


### PR DESCRIPTION
💡 What: Removed the `FIX:` prefix from a comment in `engine/camera_thread.py`.
🎯 Why: The comment documented a bug fix that was already implemented. Removing the prefix prevents TODO/FIXME scanners from flagging it as an actionable item while preserving the context for future developers.
📊 Impact: Cleans up static analysis / scanner reports by removing a false positive. No functional changes to the codebase.
🔬 Measurement: Verified the comment was correctly updated. Code review confirmed the changes are correct and safe.

---
*PR created automatically by Jules for task [15292447492667158147](https://jules.google.com/task/15292447492667158147) started by @spupuz*