### PR TITLE
🔒 Fix SSRF vulnerability in webhook notifications

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,5 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+- 2026-07-09: Validated webhooks against SSRF by disallowing link-local and multicast IPs, while permitting private/localhost IPs to support local integrations like Home Assistant.
+- 2026-07-09: Ensure requests.post uses allow_redirects=False when preventing SSRF to mitigate HTTP 302 redirect bypasses.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -14,6 +14,9 @@ import auth_service
 import datetime
 import logging
 import time
+import socket
+import ipaddress
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +203,28 @@ def _send_email_notification(
     except Exception as e:
         logger.error(f"[NOTIFY] Email failed: {e}")
 
+def is_safe_webhook_url(url: str) -> bool:
+    """
+    Validates webhook URLs to prevent SSRF while allowing localhost/private IPs.
+    Blocks non-HTTP(S) schemes and link-local (cloud metadata) / multicast IPs.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ('http', 'https'):
+            return False
+
+        # Resolve hostname to IP
+        ip_str = socket.gethostbyname(parsed.hostname)
+        ip_obj = ipaddress.ip_address(ip_str)
+
+        # Block link-local (e.g., 169.254.169.254) and multicast
+        if ip_obj.is_link_local or ip_obj.is_multicast:
+            return False
+
+        return True
+    except (ValueError, socket.gaierror, Exception):
+        return False
+
 def _send_webhook_notification(
     camera,
     event_type: str,
@@ -218,6 +243,10 @@ def _send_webhook_notification(
     if not (should_notify_webhook and webhook_url):
         return
 
+    if not is_safe_webhook_url(webhook_url):
+        logger.warning(f"[NOTIFY] Webhook URL {webhook_url} is invalid or unsafe, aborting notification.")
+        return
+
     try:
         requests.post(webhook_url, json={
             "camera_name": camera.name,
@@ -227,7 +256,7 @@ def _send_webhook_notification(
             "timestamp": details.get("timestamp"),
             "file_path": details.get("file_path"),
             "source": details.get("source", "Standard")
-        }, timeout=5)
+        }, timeout=5, allow_redirects=False)
     except Exception as e:
         logger.error(f"[NOTIFY] Webhook failed: {e}")
 

--- a/scripts/tests/test_webhook_ssrf_fix.py
+++ b/scripts/tests/test_webhook_ssrf_fix.py
@@ -1,0 +1,38 @@
+import pytest
+import sys
+import os
+from unittest.mock import patch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../backend'))
+from routers.events import is_safe_webhook_url
+
+@patch('socket.gethostbyname')
+def test_safe_urls(mock_gethostbyname):
+    # Mock successful resolution of api.example.com to a safe public IP
+    def mock_resolve(hostname):
+        if hostname == 'api.example.com':
+            return '93.184.216.34'
+        elif hostname == 'localhost':
+            return '127.0.0.1'
+        return hostname # If it's already an IP string
+    mock_gethostbyname.side_effect = mock_resolve
+
+    assert is_safe_webhook_url('http://127.0.0.1/webhook') == True
+    assert is_safe_webhook_url('http://localhost:8080/events') == True
+    assert is_safe_webhook_url('http://192.168.1.100/notify') == True
+    assert is_safe_webhook_url('https://api.example.com/webhook') == True
+
+def test_unsafe_urls():
+    # Link local / metadata
+    assert is_safe_webhook_url('http://169.254.169.254/latest/meta-data/') == False
+
+    # Invalid schemes
+    assert is_safe_webhook_url('file:///etc/passwd') == False
+    assert is_safe_webhook_url('ftp://192.168.1.1') == False
+
+    # Invalid URL structures
+    assert is_safe_webhook_url('not a url') == False
+    assert is_safe_webhook_url('') == False
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
🎯 **What:** Implemented URL validation for outbound webhook notifications (`requests.post(webhook_url)`) to prevent SSRF (Server-Side Request Forgery) attacks targeting internal cloud metadata endpoints or unauthorized schemes, while continuing to intentionally allow local/private IP destinations (like Home Assistant or Node-RED).

⚠️ **Risk:** Without validation, an attacker could supply malicious webhook URLs (like `file:///etc/passwd`, `http://169.254.169.254/latest/meta-data`, or a malicious server that returns an HTTP 302 redirect) to exploit the application's network access, potentially leaking sensitive cloud credentials or escalating privileges.

🛡️ **Solution:** Created the `is_safe_webhook_url` helper function which parses the URL to ensure it uses `http` or `https`, resolves the hostname to block link-local (`169.254.x.x`) and multicast IPs, and applied `allow_redirects=False` to the `requests.post()` call to prevent redirection bypasses.

📊 **Impact:** Enhances backend security by eliminating the SSRF vulnerability without breaking existing user workflows reliant on local network webhooks.

🔬 **Measurement:** Executed existing backend unit tests successfully and introduced `scripts/tests/test_webhook_ssrf_fix.py` to directly validate the safe and unsafe URL conditions.

---
*PR created automatically by Jules for task [15822865289205463279](https://jules.google.com/task/15822865289205463279) started by @spupuz*