### PR TITLE
🛡️ Sentinel: [HIGH] Fix Webhook Secret Timing Attack

### DIFF
--- a/.github/scripts/test_events_webhook.py
+++ b/.github/scripts/test_events_webhook.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi import HTTPException
+import hmac
+import os
+from backend.routers.events import webhook_event
+import asyncio
+from fastapi import Request
+
+@pytest.mark.asyncio
+async def test_webhook_event_invalid_secret():
+    request = MagicMock(spec=Request)
+    request.headers.get.return_value = "invalid_secret"
+    payload = {"camera_id": 1, "event_type": "motion_on"}
+    background_tasks = MagicMock()
+    db = MagicMock()
+
+    with patch.dict(os.environ, {"WEBHOOK_SECRET": "correct_secret"}):
+        with pytest.raises(HTTPException) as excinfo:
+            await webhook_event(request, payload, background_tasks, db)
+        assert excinfo.value.status_code == 401

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+
+## 2026-07-09 - Prevent Timing Attacks in Webhook Secret Validation
+**Vulnerability:** The webhook endpoint (`/events/webhook`) used a standard equality operator (`!=`) to verify the `X-Webhook-Secret` against the expected secret, making it vulnerable to timing attacks where an attacker could theoretically guess the secret character by character.
+**Learning:** When comparing sensitive cryptographic strings or security secrets (like tokens or API keys), standard string comparison should never be used. Since the equality operator fails at the first mismatched character, it creates a timing discrepancy that can be exploited.
+**Prevention:** Always use `hmac.compare_digest(provided.encode('utf-8'), expected.encode('utf-8'))` to ensure comparisons take a constant amount of time regardless of whether they match or fail early.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -14,6 +14,7 @@ import auth_service
 import datetime
 import logging
 import time
+import hmac
 
 logger = logging.getLogger(__name__)
 
@@ -537,7 +538,7 @@ async def webhook_event(
     # Use dedicated WEBHOOK_SECRET if set, otherwise fallback to SECRET_KEY
     expected_secret = os.getenv("WEBHOOK_SECRET", auth_service.SECRET_KEY)
 
-    if secret_header != expected_secret:
+    if not secret_header or not hmac.compare_digest(secret_header.encode('utf-8'), expected_secret.encode('utf-8')):
         # Avoid leaking existence or details, but allow local debugging if needed?
         # Strict security: 401.
         logger.warning("[WEBHOOK] Unauthorized access attempt (Invalid Secret).")


### PR DESCRIPTION
🛡️ **Sentinel: [HIGH] Fix Webhook Secret Timing Attack**

🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was using the standard inequality operator (`!=`) to compare the incoming `X-Webhook-Secret` header with the expected `WEBHOOK_SECRET` environment variable in the `/events/webhook` route (`backend/routers/events.py`). Standard string comparisons exit early as soon as a character mismatch is found. 
🎯 **Impact:** An attacker could theoretically measure the server's response time to deduce the correct webhook secret character by character, leading to a complete bypass of webhook authentication. This would allow an attacker to spoof internal events.
🔧 **Fix:** Replaced the simple string comparison with Python's constant-time comparison function, `hmac.compare_digest()`.
✅ **Verification:** Verified the fix by running unit tests (`.github/scripts/test_events_webhook.py`) and standard linters (`ruff check`).

---
*PR created automatically by Jules for task [1576603875541142976](https://jules.google.com/task/1576603875541142976) started by @spupuz*