### PR TITLE
⚡ Bolt: Optimize camera stats query in homepage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,7 @@
 ## 2025-02-12 - [Optimize _generate_backup_data API with selectinload]
 **Learning:** In APIs dealing with large exports (like generating full backup dictionaries of the entire database state), accessing lazy-loaded relationships during JSON serialization can trigger thousands of O(N) queries, significantly degrading performance.
 **Action:** Always eagerly load relationships using `selectinload` (e.g. `.options(selectinload(Model.relation))`) on bulk API queries that serialize nested components, particularly when assembling large data structures like backups.
+
+## 2026-07-10 - Optimize Database Counting
+**Learning:** Using `len(query.all())` fetches all records into memory, which causes O(N) memory overhead and is inefficient for counting records.
+**Action:** Use database-level aggregations like `query.with_entities(func.count(Model.id)).scalar()` or `query(func.count(Model.id)).scalar()` for an efficient O(1) query when calculating counts for dashboards or stats.

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -23,9 +23,9 @@ def get_homepage_stats(
     Requires authentication via API token (X-API-Key header).
     """
     # Camera Stats
-    cameras = db.query(models.Camera).all()
-    cameras_total = len(cameras)
-    cameras_online = len([c for c in cameras if c.is_active])
+    # ⚡ Bolt: Fetch counts directly instead of loading all models into memory (O(N) -> O(1))
+    cameras_total = db.query(func.count(models.Camera.id)).scalar() or 0
+    cameras_online = db.query(func.count(models.Camera.id)).filter(models.Camera.is_active.is_(True)).scalar() or 0
     
     # Active Recording Cameras (using LIVE_MOTION / ACTIVE_CAMERAS from events router)
     # ACTIVE_CAMERAS tracks ongoing motion events


### PR DESCRIPTION
💡 **What:** Replaced `db.query(models.Camera).all()` fetching and `len()` counting with `db.query(func.count(models.Camera.id)).scalar()` in `get_homepage_stats`.
🎯 **Why:** Loading all camera records into Python memory just to count them causes O(N) memory and processing overhead, which is inefficient for a stats dashboard, especially as the number of cameras grows.
📊 **Impact:** Reduces database transfer, memory footprint, and CPU processing for the `/homepage/stats` endpoint from O(N) to O(1) for camera counts.
🔬 **Measurement:** Verify by navigating to the Homepage dashboard and checking that camera statistics load faster and correctly represent the number of configured and active cameras without increased memory usage in the backend container.

---
*PR created automatically by Jules for task [13503349049706669291](https://jules.google.com/task/13503349049706669291) started by @spupuz*