### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack in webhook secret validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+## 2024-07-11 - Timing attack in webhook secret validation
+**Vulnerability:** Webhook secret was validated using standard string comparison `!=`, which is vulnerable to timing attacks.
+**Learning:** Standard string comparison can leak the length and characters of secrets.
+**Prevention:** Use `hmac.compare_digest` with properly encoded strings to prevent timing side channels when verifying API keys, tokens, or webhook secrets.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -14,6 +14,7 @@ import auth_service
 import datetime
 import logging
 import time
+import hmac
 
 logger = logging.getLogger(__name__)
 
@@ -537,7 +538,7 @@ async def webhook_event(
     # Use dedicated WEBHOOK_SECRET if set, otherwise fallback to SECRET_KEY
     expected_secret = os.getenv("WEBHOOK_SECRET", auth_service.SECRET_KEY)
 
-    if secret_header != expected_secret:
+    if not secret_header or not hmac.compare_digest(secret_header.encode('utf-8'), expected_secret.encode('utf-8')):
         # Avoid leaking existence or details, but allow local debugging if needed?
         # Strict security: 401.
         logger.warning("[WEBHOOK] Unauthorized access attempt (Invalid Secret).")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Webhook secret was validated using standard string comparison `!=`, which is vulnerable to timing attacks.
🎯 Impact: Attackers could potentially deduce the webhook secret by analyzing the response time of the validation.
🔧 Fix: Replaced standard string comparison with `hmac.compare_digest` and properly encoded strings to prevent timing side channels.
✅ Verification: Ran backend tests and linters successfully. Tested the `webhook_event` endpoint.

---
*PR created automatically by Jules for task [13644784941047300321](https://jules.google.com/task/13644784941047300321) started by @spupuz*