### PR TITLE
⚡ Bolt: Optimize get_homepage_stats endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2025-02-12 - [Optimize _generate_backup_data API with selectinload]
 **Learning:** In APIs dealing with large exports (like generating full backup dictionaries of the entire database state), accessing lazy-loaded relationships during JSON serialization can trigger thousands of O(N) queries, significantly degrading performance.
 **Action:** Always eagerly load relationships using `selectinload` (e.g. `.options(selectinload(Model.relation))`) on bulk API queries that serialize nested components, particularly when assembling large data structures like backups.
+## 2025-02-12 - [Optimize get_homepage_stats with SQL count]
+**Learning:** Loading all models into memory to count them (e.g. `cameras = db.query(models.Camera).all(); cameras_total = len(cameras)`) can lead to severe performance and memory usage issues, particularly when there are many entities or large nested object sets being eagerly loaded.
+**Action:** When calculating statistics like counts, always use SQL aggregation functions natively (e.g., `db.query(func.count(models.Camera.id)).scalar()`) to avoid loading unnecessary objects into Python memory.

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -23,9 +23,9 @@ def get_homepage_stats(
     Requires authentication via API token (X-API-Key header).
     """
     # Camera Stats
-    cameras = db.query(models.Camera).all()
-    cameras_total = len(cameras)
-    cameras_online = len([c for c in cameras if c.is_active])
+    # ⚡ Bolt: Prevent loading all cameras into memory just to count them
+    cameras_total = db.query(func.count(models.Camera.id)).scalar() or 0
+    cameras_online = db.query(func.count(models.Camera.id)).filter(models.Camera.is_active.is_(True)).scalar() or 0
     
     # Active Recording Cameras (using LIVE_MOTION / ACTIVE_CAMERAS from events router)
     # ACTIVE_CAMERAS tracks ongoing motion events


### PR DESCRIPTION
💡 What: Optimized the `get_homepage_stats` endpoint to use native SQL counting (`func.count(...)`) instead of fetching all camera models into Python memory and calling `len()`.
🎯 Why: The original implementation eagerly loaded all cameras (`cameras = db.query(models.Camera).all()`) just to calculate counts, which becomes a severe bottleneck as the database grows, increasing memory overhead and API latency.
📊 Impact: Reduces memory usage and database query time significantly. The operation is now an efficient O(1) count instead of O(N) loading everything into application memory.
🔬 Measurement: Verify by loading the homepage dashboard for an instance with numerous active cameras. The `get_homepage_stats` API should respond faster and consume fewer resources.

---
*PR created automatically by Jules for task [892782240216347561](https://jules.google.com/task/892782240216347561) started by @spupuz*