### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF redirect bypass in webhooks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+
+## 2024-05-28 - SSRF Redirect Bypass in Requests Library
+**Vulnerability:** Server-Side Request Forgery (SSRF) bypass through HTTP redirects in webhook delivery endpoints (`requests.post`).
+**Learning:** Even when user-provided URLs are strictly validated to block private or loopback IPs (e.g., using `ipaddress` and `socket`), the Python `requests` library follows HTTP redirects (301/302) by default. A malicious server could return a redirect to a restricted internal IP (like `127.0.0.1` or `169.254.169.254`), bypassing the initial URL validation and pivoting the request to internal infrastructure.
+**Prevention:** Always explicitly set `allow_redirects=False` when making HTTP requests to user-provided or untrusted URLs using the `requests` library, especially when implementing webhooks or external integrations, to ensure the destination remains strictly as validated.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -227,7 +227,7 @@ def _send_webhook_notification(
             "timestamp": details.get("timestamp"),
             "file_path": details.get("file_path"),
             "source": details.get("source", "Standard")
-        }, timeout=5)
+        }, timeout=5, allow_redirects=False)
     except Exception as e:
         logger.error(f"[NOTIFY] Webhook failed: {e}")
 

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -830,7 +830,7 @@ def test_notification(config: schemas.TestNotificationConfig, db: Session = Depe
                 "timestamp": datetime.datetime.now().isoformat()
             }
             
-            resp = requests.post(url, json=payload, timeout=10)
+            resp = requests.post(url, json=payload, timeout=10, allow_redirects=False)
             if not resp.ok:
                 raise ValueError(f"Webhook returned error: {resp.status_code} {resp.text}")
                 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SSRF redirect bypass in webhooks

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) bypass through HTTP redirects in webhook delivery endpoints (`requests.post`).
🎯 **Impact:** Even when user-provided URLs are strictly validated to block private or loopback IPs, a malicious server could return an HTTP redirect (301/302) pointing to a restricted internal IP (like 127.0.0.1 or AWS Metadata at 169.254.169.254). The Python `requests` library follows these redirects by default, bypassing the initial URL validation and pivoting the request to internal infrastructure.
🔧 **Fix:** Explicitly set `allow_redirects=False` in all `requests.post()` calls for webhook deliveries to ensure the destination strictly remains the initially validated URL.
✅ **Verification:** Verified by checking the updated webhook calls in `events.py` and `settings.py` and running tests.

---
*PR created automatically by Jules for task [9012879255707977306](https://jules.google.com/task/9012879255707977306) started by @spupuz*