### PR TITLE
🎨 Palette: Add accessible ARIA labels to timeline filter controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-06-27 - [Add ARIA labels to icon-only buttons]
 **Learning:** When making UX accessibility improvements, avoid the anti-pattern of adding an `aria-label` that is exactly identical to the visible text content of an interactive element (e.g., a button), as screen readers natively announce text content, and duplicate labels cause redundant announcements. However, for buttons that only have an icon, or text that might be hidden or visually truncated, `aria-label`s are still necessary.
 **Action:** Add `aria-label` attributes to icon-only buttons for better screen reader accessibility.
+## 2026-07-13 - [Accessible Labels for Inline Filters and Selects]
+**Learning:** Compact inline filter bars and media controls often omit visible text labels (using only icons or placeholder text) to save space. While this visually works, it leaves form elements like `<select>` and `<input>` without accessible names for screen readers, breaking accessibility.
+**Action:** Always provide explicitly descriptive `aria-label` attributes to form elements (like selects and inputs) that lack an associated visible `<label>`, ensuring screen readers can correctly announce their purpose.

--- a/frontend/src/components/Timeline/EventFilters.jsx
+++ b/frontend/src/components/Timeline/EventFilters.jsx
@@ -43,6 +43,7 @@ export const EventFilters = ({
             {/* Camera Filter */}
             <div className="relative">
                 <select
+                    aria-label={t('timeline.filter_by_camera', 'Filter by Camera')}
                     className="appearance-none pl-3 pr-8 py-2 bg-card border border-border rounded-xl text-sm min-w-[140px] focus:ring-2 focus:ring-primary/20 outline-none transition-all hover:border-primary/50 text-foreground"
                     value={selectedCameraFilter}
                     onChange={(e) => {
@@ -66,6 +67,7 @@ export const EventFilters = ({
             {/* Media Type Filter */}
             <div className="relative">
                 <select
+                    aria-label={t('timeline.filter_by_media_type', 'Filter by Media Type')}
                     className="appearance-none pl-3 pr-8 py-2 bg-card border border-border rounded-xl text-sm min-w-[120px] focus:ring-2 focus:ring-primary/20 outline-none transition-all hover:border-primary/50 text-foreground"
                     value={selectedTypeFilter}
                     onChange={(e) => {
@@ -88,6 +90,7 @@ export const EventFilters = ({
             {/* Event Type Filter */}
             <div className="relative">
                 <select
+                    aria-label={t('timeline.filter_by_event_type', 'Filter by Event Type')}
                     className="appearance-none pl-3 pr-8 py-2 bg-card border border-border rounded-xl text-sm min-w-[120px] focus:ring-2 focus:ring-primary/20 outline-none transition-all hover:border-primary/50 text-foreground"
                     value={selectedEventTypeFilter}
                     onChange={(e) => {
@@ -110,6 +113,7 @@ export const EventFilters = ({
             {/* Object Type Filter */}
             <div className="relative">
                 <select
+                    aria-label={t('timeline.filter_by_object_type', 'Filter by Object Type')}
                     className="appearance-none pl-3 pr-8 py-2 bg-card border border-border rounded-xl text-sm min-w-[130px] focus:ring-2 focus:ring-primary/20 outline-none transition-all hover:border-primary/50 text-foreground"
                     value={selectedObjectFilter}
                     onChange={(e) => {
@@ -131,6 +135,7 @@ export const EventFilters = ({
             <div className="relative flex items-center">
                 <input
                     type="date"
+                    aria-label={t('timeline.filter_by_date', 'Filter by Date')}
                     className="pl-9 pr-3 py-2 bg-card border border-border rounded-xl text-sm focus:ring-2 focus:ring-primary/20 outline-none transition-all hover:border-primary/50 text-foreground"
                     value={selectedDate}
                     onChange={(e) => {

--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -76,6 +76,7 @@ export const EventPreview = ({
                             <span className="text-[10px] font-bold text-foreground/80 uppercase tracking-tighter">{t('timeline.auto_next', 'Auto-next')}</span>
                             {autoplayNext && (
                                 <select
+                                    aria-label={t('timeline.playback_order', 'Playback Order')}
                                     value={autoplayDirection}
                                     onChange={(e) => {
                                         e.preventDefault();
@@ -123,6 +124,7 @@ export const EventPreview = ({
                     {selectedEvent.type === 'video' && (
                         <div className="absolute top-2 right-2 px-2.5 py-1 rounded-md backdrop-blur-md shadow-lg bg-black/40 border border-white/20 active:scale-90 transition-all">
                             <select
+                                aria-label={t('timeline.playback_speed', 'Playback Speed')}
                                 value={playbackSpeed}
                                 onChange={(e) => setPlaybackSpeed(Number(e.target.value))}
                                 className="bg-transparent text-xs font-black text-white/90 border-none focus:ring-0 cursor-pointer p-0 text-center w-8 appearance-none"
@@ -170,6 +172,7 @@ export const EventPreview = ({
                         <label htmlFor="autoplayNextDesktop" className="text-xs font-medium cursor-pointer select-none">{t('timeline.auto_next', 'Auto-next')}</label>
                         {autoplayNext && (
                             <select
+                                aria-label={t('timeline.playback_order', 'Playback Order')}
                                 value={autoplayDirection}
                                 onChange={(e) => setAutoplayDirection(e.target.value)}
                                 className="ml-1 h-5 text-[10px] bg-transparent border-none focus:ring-0 cursor-pointer text-muted-foreground hover:text-foreground p-0 pr-1 pl-1"
@@ -185,6 +188,7 @@ export const EventPreview = ({
                     {selectedEvent.type === 'video' && (
                         <div className="flex items-center space-x-1 bg-muted/50 hover:bg-muted rounded-lg px-2 py-1 transition-colors border border-transparent hover:border-border">
                             <select
+                                aria-label={t('timeline.playback_speed', 'Playback Speed')}
                                 value={playbackSpeed}
                                 onChange={(e) => setPlaybackSpeed(Number(e.target.value))}
                                 className="bg-transparent text-xs font-bold text-foreground border-none focus:ring-0 cursor-pointer p-0 text-center w-12 appearance-none"


### PR DESCRIPTION
💡 What: Added explicitly descriptive `aria-label` attributes to the compact inline `<select>` and `<input>` filter controls in the Timeline view (`EventFilters.jsx` and `EventPreview.jsx`).
🎯 Why: Compact inline filter bars often omit visible text labels to save space. Without explicit `aria-label`s, screen readers cannot properly identify the purpose of these form elements, breaking accessibility for visually impaired users.
📸 Before/After: Visuals remain entirely unchanged; the modifications only affect screen reader announcements.
♿ Accessibility: Ensures that screen reader users can understand and interact with all the filter options (Camera, Media Type, Date, etc.) and playback controls in the timeline views.

---
*PR created automatically by Jules for task [5981140532448512427](https://jules.google.com/task/5981140532448512427) started by @spupuz*