### PR TITLE
⚡ Bolt: Optimize get_homepage_stats memory usage by resolving O(N) database reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2025-02-12 - [Optimize _generate_backup_data API with selectinload]
 **Learning:** In APIs dealing with large exports (like generating full backup dictionaries of the entire database state), accessing lazy-loaded relationships during JSON serialization can trigger thousands of O(N) queries, significantly degrading performance.
 **Action:** Always eagerly load relationships using `selectinload` (e.g. `.options(selectinload(Model.relation))`) on bulk API queries that serialize nested components, particularly when assembling large data structures like backups.
+## 2025-02-12 - [Optimize get_homepage_stats API with func.count]
+**Learning:** When calculating counts of database records in SQLAlchemy (e.g., for dashboards or stats), avoid fetching all records into memory using `len(query.all())` which causes O(N) memory overhead and excessive data transfer.
+**Action:** Instead, use database-level aggregations like `query.with_entities(func.count(Model.id)).scalar()` or `db.query(func.count(Model.id)).scalar()` for an efficient O(1) query.

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -23,9 +23,9 @@ def get_homepage_stats(
     Requires authentication via API token (X-API-Key header).
     """
     # Camera Stats
-    cameras = db.query(models.Camera).all()
-    cameras_total = len(cameras)
-    cameras_online = len([c for c in cameras if c.is_active])
+    # ⚡ Bolt: Resolving O(N) memory overhead and data transfer by avoiding loading all camera objects into memory.
+    cameras_total = db.query(func.count(models.Camera.id)).scalar() or 0
+    cameras_online = db.query(func.count(models.Camera.id)).filter(models.Camera.is_active.is_(True)).scalar() or 0
     
     # Active Recording Cameras (using LIVE_MOTION / ACTIVE_CAMERAS from events router)
     # ACTIVE_CAMERAS tracks ongoing motion events


### PR DESCRIPTION
💡 What:
Replaced the `len(db.query(models.Camera).all())` queries in `get_homepage_stats` with native SQLAlchemy aggregations using `func.count()`. 

🎯 Why:
The original approach loaded all `Camera` database objects into Python memory just to compute their total length and active count. This created an `O(N)` memory overhead and unnecessary database data transfer which would scale poorly as the number of cameras in the system increases.

📊 Impact:
Reduces memory overhead and data transfer significantly when querying stats. The query logic transitions from `O(N)` database retrieval to an efficient `O(1)` aggregation.

🔬 Measurement:
No behavioral change. Verify the homepage stats are populated correctly by running `PYTHONPATH=engine:backend python3 -m pytest .github/scripts/test_crud.py` and starting the backend server.

---
*PR created automatically by Jules for task [5319342167620898919](https://jules.google.com/task/5319342167620898919) started by @spupuz*