### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in webhooks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** External input (e.g. URLs or file paths) passed directly to `ffmpeg` or `ffprobe` commands via `subprocess.run()` without preceding argument identifiers can be misinterpreted as command-line flags (e.g. if an input starts with `-`), leading to argument/command injection.
 **Learning:** Always explicitly mark inputs with the appropriate flag (like `-i`) to guarantee that `ffmpeg`/`ffprobe` correctly interprets the following string as an input source and not an arbitrary, potentially malicious flag, regardless of previous path sanitization.
 **Prevention:** Ensure every dynamic path or URL passed to a `subprocess.run` list for `ffmpeg` or `ffprobe` is immediately preceded by the `-i` flag.
+
+## 2024-07-15 - Prevent SSRF in Webhooks
+**Vulnerability:** Server-Side Request Forgery (SSRF) was possible via webhook functionality. Webhook URLs were not validated, allowing malicious actors to point webhooks at internal or cloud metadata IP addresses (e.g., `169.254.169.254`). Also, `allow_redirects=False` was missing, which could bypass validation if an attacker set up an external server that redirects to an internal IP.
+**Learning:** Even when functionality intentionally allows external connections, IP resolution must occur to block internal or sensitive cloud endpoints. Redirects in HTTP clients can bypass pre-request URL validation.
+**Prevention:** Implement an IP resolution check using `socket.gethostbyname` to identify and block link-local and multicast IPs. Additionally, enforce `allow_redirects=False` in network request clients (e.g., `requests.post`) to prevent redirect-based SSRF bypasses.

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -9,6 +9,7 @@ import os
 import requests
 import threading
 import models
+import utils
 import subprocess
 import auth_service
 import datetime
@@ -218,6 +219,10 @@ def _send_webhook_notification(
     if not (should_notify_webhook and webhook_url):
         return
 
+    if not utils.is_safe_webhook_url(webhook_url):
+        logger.error(f"[NOTIFY] Webhook failed: Unsafe webhook URL blocked")
+        return
+
     try:
         requests.post(webhook_url, json={
             "camera_name": camera.name,
@@ -227,7 +232,7 @@ def _send_webhook_notification(
             "timestamp": details.get("timestamp"),
             "file_path": details.get("file_path"),
             "source": details.get("source", "Standard")
-        }, timeout=5)
+        }, timeout=5, allow_redirects=False)
     except Exception as e:
         logger.error(f"[NOTIFY] Webhook failed: {e}")
 

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -18,6 +18,7 @@ import backup_service
 import requests
 import os
 import telemetry_service
+import utils
 import settings_service
 
 logger = logging.getLogger(__name__)
@@ -824,13 +825,16 @@ def test_notification(config: schemas.TestNotificationConfig, db: Session = Depe
             if not url:
                 raise ValueError("Missing Webhook URL. Configure it in Global Settings first.")
                 
+            if not utils.is_safe_webhook_url(url):
+                raise ValueError("Unsafe Webhook URL. Link-local and multicast IPs are blocked.")
+
             payload = {
                 "event": "test",
                 "message": "VibeNVR Test Webhook",
                 "timestamp": datetime.datetime.now().isoformat()
             }
             
-            resp = requests.post(url, json=payload, timeout=10)
+            resp = requests.post(url, json=payload, timeout=10, allow_redirects=False)
             if not resp.ok:
                 raise ValueError(f"Webhook returned error: {resp.status_code} {resp.text}")
                 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,4 +1,32 @@
 import re
+import socket
+import ipaddress
+from urllib.parse import urlparse
+
+def is_safe_webhook_url(url: str) -> bool:
+    """Check if a webhook URL is safe from SSRF attacks."""
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ('http', 'https'):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Resolve hostname to IP
+        ip = socket.gethostbyname(hostname)
+        ip_obj = ipaddress.ip_address(ip)
+
+        # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
+        # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
+        # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
+        if ip_obj.is_link_local or ip_obj.is_multicast:
+            return False
+
+        return True
+    except Exception:
+        return False
 
 def mask_url(text: str) -> str:
     """Mask credentials in RTSP/HTTP URLs for safe logging."""


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: Server-Side Request Forgery (SSRF) was possible via webhook functionality. Webhook URLs were not validated against a blocklist, allowing malicious actors to point webhooks at internal or cloud metadata IP addresses (e.g., `169.254.169.254`). Additionally, `allow_redirects=False` was missing in `requests.post` calls, which could bypass validation if an attacker set up an external server that redirects to an internal IP.

🎯 **Impact**: Attackers could exploit the webhook endpoints to perform port scanning on the internal network, interact with internal services, or access sensitive cloud metadata (e.g., AWS EC2 metadata credentials) by providing a malicious URL.

🔧 **Fix**: 
- Implemented `is_safe_webhook_url` in `backend/utils.py` that resolves the webhook hostname to an IP address using `socket.gethostbyname` and validates it against link-local (`169.254.x.x`) and multicast addresses using the `ipaddress` module.
- Integrated the validation check into `_send_webhook_notification` (`backend/routers/events.py`) and `test_notification` (`backend/routers/settings.py`).
- Explicitly set `allow_redirects=False` on `requests.post` calls to prevent redirect-based SSRF bypasses.
- Note: Private IPs (e.g., `192.168.x.x`) are intentionally allowed as NVR users commonly use webhooks for local home automation (e.g., Home Assistant) integrations.

✅ **Verification**: 
- Passed `ruff check` in the backend.
- Passed existing `pytest` CRUD tests.
- Manually confirmed the `is_safe_webhook_url` function correctly blocks `169.254.169.254` and allows public and private IPs.

---
*PR created automatically by Jules for task [7089077183196203126](https://jules.google.com/task/7089077183196203126) started by @spupuz*