### PR TITLE
🐛 Fix motion state extending during AI persistence window

### DIFF
--- a/engine/camera_thread.py
+++ b/engine/camera_thread.py
@@ -328,7 +328,7 @@ class CameraThread(threading.Thread):
                         if (time.time() - self.last_ai_update_time) < persist_window:
                             ai_results = self.latest_ai_results
                             # FIX: Ensure motion state persists during the AI persistence window
-                            self.motion_detector.last_motion_time = time.time()
+                            self.motion_detector.last_motion_time = self.last_ai_update_time
                     
                     # Handle Motion End for AI
                     motion_gap = self.config.get('motion_gap', 10)


### PR DESCRIPTION
Fixes an issue where the `motion_detector.last_motion_time` was being updated to the current system time (`time.time()`) during the AI results persistence window, which inadvertently extended the motion state by up to 10 extra seconds. It now accurately tracks the actual time of the AI detection (`self.last_ai_update_time`) to allow `motion_gap` logic to work as originally intended.

---
*PR created automatically by Jules for task [8453540662858329451](https://jules.google.com/task/8453540662858329451) started by @spupuz*