### PR TITLE
fix(engine): fix AI motion state persistence logic when ignoring exclusion zones

### DIFF
--- a/engine/camera_thread.py
+++ b/engine/camera_thread.py
@@ -316,6 +316,9 @@ class CameraThread(threading.Thread):
                             
                             # Broadcast AI metadata to WebCodecs clients
                             self.stream_reader.broadcast_metadata(ai_results)
+                        elif raw_ai_results:
+                            logger.debug(f"Camera {self.config.get('name')} (ID: {self.camera_id}): AI inference ignored (object inside mask/exclusion zone)")
+                            self.latest_ai_results = []
                     
                     # Persistence: reuse latest AI results while motion is still considered active.
                     # - If motion_detected=True: keep the box visible for up to motion_gap seconds


### PR DESCRIPTION
Fixed AI motion persistence logic edge case.

🎯 **What:**
When AI inference detects objects, but they are all filtered out because they lie inside exclusion zones, the system now explicitly drops the tracking state (`self.latest_ai_results`) and logs that the inference was ignored.

💡 **Why:**
Previously, dropping into the `else` case of AI filtering left `latest_ai_results` populated. The subsequent persistence window logic then saw `latest_ai_results` and artificially extended the motion persistence, causing the state to incorrectly persist even though the object was technically ignored.

✅ **Verification:**
Added and successfully verified localized testing, and ensured all related `test_motion_service.py` unit tests pass. 

✨ **Result:**
The system now correctly drops tracking and motion when the only detected objects walk into a mask/exclusion zone.

---
*PR created automatically by Jules for task [691861444930605775](https://jules.google.com/task/691861444930605775) started by @spupuz*