### PR TITLE
🧹 [remove leftover console.log from OnvifTab]

### DIFF
--- a/frontend/src/components/Cameras/AddEditModal/Tabs/OnvifTab.jsx
+++ b/frontend/src/components/Cameras/AddEditModal/Tabs/OnvifTab.jsx
@@ -20,7 +20,6 @@ export const OnvifTab = ({ newCamera, setNewCamera }) => {
     useEffect(() => {
         const hasHost = newCamera.onvif_host && newCamera.onvif_host.trim() !== '';
         if (!hasHost && newCamera.rtsp_url) {
-            console.log("OnvifTab: Auto-filling from RTSP URL...");
             const { user, pass, host } = parseRtspUrl(newCamera.rtsp_url);
             // Extract IP/Host from RTSP host (which might include port)
             const IPOnly = host?.split(':')[0];


### PR DESCRIPTION
🎯 **What:** Removed a leftover `console.log("OnvifTab: Auto-filling from RTSP URL...");` statement from `frontend/src/components/Cameras/AddEditModal/Tabs/OnvifTab.jsx`.
💡 **Why:** Removing unnecessary debugging statements improves the cleanliness and maintainability of the codebase, preventing log spam and enhancing readability.
✅ **Verification:** Verified the code changes locally by running `pnpm lint` and `pnpm build` in the frontend directory to ensure the build succeeds and no functionality is broken.
✨ **Result:** A cleaner component file without noisy console output during runtime, preserving all existing Auto-fill functionality exactly as it was.

---
*PR created automatically by Jules for task [16365194118729833798](https://jules.google.com/task/16365194118729833798) started by @spupuz*