### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility to timeline hour filter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-06 - Add semantic dialog roles to custom modals
 **Learning:** Custom modal components built with Portals need explicit `role="dialog"`, `aria-modal="true"`, and aria labels (`aria-labelledby`/`aria-describedby`) mapped to their title/description elements to be correctly announced by screen readers when they open.
 **Action:** Always ensure custom dialog/modal components include these semantic ARIA attributes.
+
+## 2024-05-22 - Interactive custom timeline elements require explicit keyboard and screen reader support
+**Learning:** When building custom interactive elements (like the hour filter `div`s in the timeline) instead of using native `<button>`s, it's critical to add `role="button"`, `tabIndex={0}`, `onKeyDown` listeners for 'Enter'/'Space', and clear `aria-label`s and focus indicators (`focus-visible`). Otherwise, these elements are completely inaccessible to keyboard and screen reader users.
+**Action:** Always verify keyboard navigability and semantic ARIA roles for custom clickable UI components, especially in complex interfaces like timelines.

--- a/frontend/src/components/Timeline/HourTimeline.jsx
+++ b/frontend/src/components/Timeline/HourTimeline.jsx
@@ -38,8 +38,18 @@ export const HourTimeline = React.memo(({ events, onHourClick, selectedHour }) =
                     return (
                         <div
                             key={hour}
-                            className={`flex items-center cursor-pointer group flex-1 min-h-0 ${isCurrent ? 'bg-primary/5' : ''}`}
+                            className={`flex items-center cursor-pointer group flex-1 min-h-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:z-10 ${isCurrent ? 'bg-primary/5' : ''}`}
                             onClick={() => onHourClick(hour)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    onHourClick(hour);
+                                }
+                            }}
+                            role="button"
+                            tabIndex={0}
+                            aria-label={`Filter events for ${hour}:00`}
+                            aria-pressed={selectedHour === hour}
                         >
                             <span className={`text-[8px] w-5 text-right mr-1 ${isCurrent ? 'text-primary font-bold' : 'text-muted-foreground'}`}>
                                 {hour.toString().padStart(2, '0')}


### PR DESCRIPTION
💡 What: Added comprehensive keyboard and screen reader accessibility support to the interactive timeline hour filters, which were previously custom `div` elements lacking standard button semantics.
🎯 Why: Without these attributes, keyboard-only users could not tab to or activate the timeline filters, and screen readers could not identify the elements' purpose or current state.
📸 Before/After: Visual changes are limited to a focus ring that only appears during keyboard navigation.
♿ Accessibility:
- Added `role="button"` and `tabIndex={0}` to make the element focusable.
- Added `onKeyDown` listener to trigger the click handler when 'Enter' or 'Space' is pressed.
- Added `aria-label` and `aria-pressed` to communicate the element's purpose and state to assistive technologies.
- Added `focus-visible` utility classes to provide a clear visual indicator exclusively for keyboard users.

---
*PR created automatically by Jules for task [13740297897012904991](https://jules.google.com/task/13740297897012904991) started by @spupuz*