### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,6 @@
 ## 2026-07-16 - [Fix blocking sleep in FastAPI lifespan]
 **Learning:** When refactoring blocking calls (e.g., `time.sleep`) to async equivalents (e.g., `asyncio.sleep`) in FastAPI lifespan or other async contexts, carefully check for nested synchronous functions or background threads (like `run_orphan_recovery`) in the same file that still rely on the original synchronous module before removing their imports.
 **Action:** Ensure synchronous functions inside async files correctly import and use synchronous versions of blocking operations.
+## 2025-02-12 - [Optimize bulk deletions in storage cleanup]
+**Learning:** In backend loops processing storage cleanup deletions, querying the database for the oldest item individually inside a `while` loop with `.first()` causes severe N+1 query performance degradation.
+**Action:** Always refactor iterative single-record fetches in deletion loops to batched queries using `.limit(100).all()` and defer `db.commit()` outside the inner batch loop to execute as a single efficient transaction.

--- a/backend/storage_service.py
+++ b/backend/storage_service.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import logging
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 import models
@@ -17,14 +17,15 @@ PRESERVE_MAP = {
     "For One Week": timedelta(weeks=1),
     "For One Month": timedelta(days=30),
     "For One Year": timedelta(days=365),
-    "Forever": None
+    "Forever": None,
 }
+
 
 def translate_path(p):
     """Translate DB path (container-internal engine path) to backend container path"""
     if not p:
         return None
-    
+
     # If the path already exists as-is, return it (e.g. if shared mount exists in both containers)
     if os.path.exists(p):
         return p
@@ -40,8 +41,9 @@ def translate_path(p):
         mapped = p.replace("/var/lib/motion", "/data", 1)
         if os.path.exists(mapped):
             return mapped
-            
+
     return p
+
 
 def get_dir_size(path):
     """Get size of directory in bytes"""
@@ -57,6 +59,7 @@ def get_dir_size(path):
     except Exception as e:
         logger.error(f"Error calculating directory size for {path}: {e}")
     return total_size
+
 
 def delete_event_media(event, db: Session, reason="Unknown"):
     """Delete media files associated with an event and the event itself from DB"""
@@ -78,77 +81,125 @@ def delete_event_media(event, db: Session, reason="Unknown"):
 
         # Security Check: Ensure we only delete files inside /data
         if file_path and not os.path.abspath(file_path).startswith("/data/"):
-             logger.warning(f"Security blocked deletion of unsafe path: {file_path}")
-             file_path = None
-        
+            logger.warning(f"Security blocked deletion of unsafe path: {file_path}")
+            file_path = None
+
         if thumb_path and not os.path.abspath(thumb_path).startswith("/data/"):
-             logger.warning(f"Security blocked deletion of unsafe path: {thumb_path}")
-             thumb_path = None
+            logger.warning(f"Security blocked deletion of unsafe path: {thumb_path}")
+            thumb_path = None
 
         if file_path and os.path.exists(file_path):
             os.remove(file_path)
             logger.info(f"[{reason}] Deleted files for event {event.id}: {file_path}")
-        
+
         if thumb_path and os.path.exists(thumb_path):
             os.remove(thumb_path)
-        
+
         db.delete(event)
         return True
     except Exception as e:
         logger.error(f"Error deleting event {event.id}: {e}")
         return False
 
-def cleanup_camera(db: Session, camera: models.Camera, media_type: str = None, skip_time_retention: bool = False):
+
+def cleanup_camera(
+    db: Session,
+    camera: models.Camera,
+    media_type: str = None,
+    skip_time_retention: bool = False,
+):
     """
     Enforce storage limits and retention for a specific camera.
     media_type: 'video' | 'snapshot' | None (both)
     skip_time_retention: If True, only enforces size-based quotas
     """
     # 1. Cleanup Movies (max_storage_gb)
-    if (not media_type or media_type == 'video') and camera.max_storage_gb and camera.max_storage_gb > 0:
-        total_movies_size = db.query(func.sum(models.Event.file_size)).filter(
-            models.Event.camera_id == camera.id, 
-            models.Event.type == "video"
-        ).scalar() or 0
-        
+    if (
+        (not media_type or media_type == "video")
+        and camera.max_storage_gb
+        and camera.max_storage_gb > 0
+    ):
+        total_movies_size = (
+            db.query(func.sum(models.Event.file_size))
+            .filter(models.Event.camera_id == camera.id, models.Event.type == "video")
+            .scalar()
+            or 0
+        )
+
         movies_used_gb = total_movies_size / (1024**3)
         if movies_used_gb > camera.max_storage_gb:
-            logger.info(f"Camera {camera.name} MOVIE limit exceeded: {movies_used_gb:.2f}GB > {camera.max_storage_gb:.2f}GB")
+            logger.info(
+                f"Camera {camera.name} MOVIE limit exceeded: {movies_used_gb:.2f}GB > {camera.max_storage_gb:.2f}GB"
+            )
             target_gb = camera.max_storage_gb * 0.95
             while movies_used_gb > target_gb:
-                oldest = db.query(models.Event).filter(
-                    models.Event.camera_id == camera.id, 
-                    models.Event.type == "video"
-                ).order_by(models.Event.timestamp_start.asc()).first()
-                if not oldest: break
-                
-                size_gb = (oldest.file_size / (1024**3)) if oldest.file_size else 0.05
-                delete_event_media(oldest, db, reason="Camera Quota (Video)")
+                batch = (
+                    db.query(models.Event)
+                    .filter(
+                        models.Event.camera_id == camera.id,
+                        models.Event.type == "video",
+                    )
+                    .order_by(models.Event.timestamp_start.asc())
+                    .limit(100)
+                    .all()
+                )
+                if not batch:
+                    break
+
+                for oldest in batch:
+                    if movies_used_gb <= target_gb:
+                        break
+                    size_gb = (
+                        (oldest.file_size / (1024**3)) if oldest.file_size else 0.05
+                    )
+                    delete_event_media(oldest, db, reason="Camera Quota (Video)")
+                    movies_used_gb -= size_gb
                 db.commit()
-                movies_used_gb -= size_gb
 
     # 2. Cleanup Pictures (max_pictures_storage_gb)
-    if (not media_type or media_type == 'snapshot') and camera.max_pictures_storage_gb and camera.max_pictures_storage_gb > 0:
-        total_pics_size = db.query(func.sum(models.Event.file_size)).filter(
-            models.Event.camera_id == camera.id, 
-            models.Event.type == "snapshot"
-        ).scalar() or 0
-        
+    if (
+        (not media_type or media_type == "snapshot")
+        and camera.max_pictures_storage_gb
+        and camera.max_pictures_storage_gb > 0
+    ):
+        total_pics_size = (
+            db.query(func.sum(models.Event.file_size))
+            .filter(
+                models.Event.camera_id == camera.id, models.Event.type == "snapshot"
+            )
+            .scalar()
+            or 0
+        )
+
         pics_used_gb = total_pics_size / (1024**3)
         if pics_used_gb > camera.max_pictures_storage_gb:
-            logger.info(f"Camera {camera.name} PICTURE limit exceeded: {pics_used_gb:.2f}GB > {camera.max_pictures_storage_gb:.2f}GB")
+            logger.info(
+                f"Camera {camera.name} PICTURE limit exceeded: {pics_used_gb:.2f}GB > {camera.max_pictures_storage_gb:.2f}GB"
+            )
             target_gb = camera.max_pictures_storage_gb * 0.95
             while pics_used_gb > target_gb:
-                oldest = db.query(models.Event).filter(
-                    models.Event.camera_id == camera.id, 
-                    models.Event.type == "snapshot"
-                ).order_by(models.Event.timestamp_start.asc()).first()
-                if not oldest: break
-                
-                size_gb = (oldest.file_size / (1024**3)) if oldest.file_size else 0.001
-                delete_event_media(oldest, db, reason="Camera Quota (Snapshot)")
+                batch = (
+                    db.query(models.Event)
+                    .filter(
+                        models.Event.camera_id == camera.id,
+                        models.Event.type == "snapshot",
+                    )
+                    .order_by(models.Event.timestamp_start.asc())
+                    .limit(100)
+                    .all()
+                )
+                if not batch:
+                    break
+
+                for oldest in batch:
+                    if pics_used_gb <= target_gb:
+                        break
+                    size_gb = (
+                        (oldest.file_size / (1024**3)) if oldest.file_size else 0.001
+                    )
+                    delete_event_media(oldest, db, reason="Camera Quota (Snapshot)")
+                    pics_used_gb -= size_gb
                 db.commit()
-                pics_used_gb -= size_gb
 
     # 3. Time-based cleanup
     if skip_time_retention:
@@ -156,10 +207,14 @@ def cleanup_camera(db: Session, camera: models.Camera, media_type: str = None, s
 
     # Use timezone-aware cutoff to match DB timestamps
     now_aware = datetime.now().astimezone()
-    
-    if not media_type or media_type == 'video':
+
+    if not media_type or media_type == "video":
         movie_delta = PRESERVE_MAP.get(camera.preserve_movies)
-        if movie_delta is None and camera.preserve_movies and camera.preserve_movies != "Forever":
+        if (
+            movie_delta is None
+            and camera.preserve_movies
+            and camera.preserve_movies != "Forever"
+        ):
             try:
                 days = int(camera.preserve_movies)
                 if days > 0:
@@ -169,16 +224,30 @@ def cleanup_camera(db: Session, camera: models.Camera, media_type: str = None, s
 
         if movie_delta:
             cutoff = now_aware - movie_delta
-            expired = db.query(models.Event).filter(models.Event.camera_id == camera.id, models.Event.type == "video", models.Event.timestamp_start < cutoff).all()
+            expired = (
+                db.query(models.Event)
+                .filter(
+                    models.Event.camera_id == camera.id,
+                    models.Event.type == "video",
+                    models.Event.timestamp_start < cutoff,
+                )
+                .all()
+            )
             if expired:
-                logger.info(f"Deleting {len(expired)} expired movies for camera {camera.name} (Cutoff: {cutoff})")
+                logger.info(
+                    f"Deleting {len(expired)} expired movies for camera {camera.name} (Cutoff: {cutoff})"
+                )
                 for e in expired:
                     delete_event_media(e, db, reason="Retention Time (Video)")
                 db.commit()
 
-    if not media_type or media_type == 'snapshot':
+    if not media_type or media_type == "snapshot":
         pic_delta = PRESERVE_MAP.get(camera.preserve_pictures)
-        if pic_delta is None and camera.preserve_pictures and camera.preserve_pictures != "Forever":
+        if (
+            pic_delta is None
+            and camera.preserve_pictures
+            and camera.preserve_pictures != "Forever"
+        ):
             try:
                 days = int(camera.preserve_pictures)
                 if days > 0:
@@ -188,12 +257,23 @@ def cleanup_camera(db: Session, camera: models.Camera, media_type: str = None, s
 
         if pic_delta:
             cutoff = now_aware - pic_delta
-            expired = db.query(models.Event).filter(models.Event.camera_id == camera.id, models.Event.type == "snapshot", models.Event.timestamp_start < cutoff).all()
+            expired = (
+                db.query(models.Event)
+                .filter(
+                    models.Event.camera_id == camera.id,
+                    models.Event.type == "snapshot",
+                    models.Event.timestamp_start < cutoff,
+                )
+                .all()
+            )
             if expired:
-                logger.info(f"Deleting {len(expired)} expired pictures for camera {camera.name} (Cutoff: {cutoff})")
+                logger.info(
+                    f"Deleting {len(expired)} expired pictures for camera {camera.name} (Cutoff: {cutoff})"
+                )
                 for e in expired:
                     delete_event_media(e, db, reason="Retention Time (Snapshot)")
                 db.commit()
+
 
 def cleanup_profile(db: Session, profile: models.StorageProfile):
     """
@@ -203,33 +283,51 @@ def cleanup_profile(db: Session, profile: models.StorageProfile):
         return
 
     # Calculate total size of all events using this profile
-    events_query = db.query(models.Event).join(models.Camera).filter(models.Camera.storage_profile_id == profile.id)
-    
-    total_size_bytes = db.query(func.sum(models.Event.file_size)).join(models.Camera).filter(models.Camera.storage_profile_id == profile.id).scalar() or 0
-    
+    events_query = (
+        db.query(models.Event)
+        .join(models.Camera)
+        .filter(models.Camera.storage_profile_id == profile.id)
+    )
+
+    total_size_bytes = (
+        db.query(func.sum(models.Event.file_size))
+        .join(models.Camera)
+        .filter(models.Camera.storage_profile_id == profile.id)
+        .scalar()
+        or 0
+    )
+
     current_used_gb = total_size_bytes / (1024**3)
-    
+
     if current_used_gb > profile.max_size_gb:
-        logger.info(f"Storage Profile '{profile.name}' limit exceeded: {current_used_gb:.2f}GB > {profile.max_size_gb:.2f}GB")
+        logger.info(
+            f"Storage Profile '{profile.name}' limit exceeded: {current_used_gb:.2f}GB > {profile.max_size_gb:.2f}GB"
+        )
         target_gb = profile.max_size_gb * 0.95
-        
+
         while current_used_gb > target_gb:
             # Delete oldest events across all cameras in this profile in batches
-            batch = events_query.order_by(models.Event.timestamp_start.asc()).limit(100).all()
-            if not batch: break
-            
+            batch = (
+                events_query.order_by(models.Event.timestamp_start.asc())
+                .limit(100)
+                .all()
+            )
+            if not batch:
+                break
+
             for oldest in batch:
                 if current_used_gb <= target_gb:
                     break
 
                 size_gb = (oldest.file_size / (1024**3)) if oldest.file_size else 0
                 if size_gb == 0:
-                     size_gb = 0.05 # Conservative estimate (50MB) for untracked videos
+                    size_gb = 0.05  # Conservative estimate (50MB) for untracked videos
 
                 delete_event_media(oldest, db, reason=f"Profile Quota ({profile.name})")
                 current_used_gb -= size_gb
-            
+
             db.commit()
+
 
 def cleanup_temp_files():
     """Delete usage-dependent temporary files (e.g. notification snapshots) older than 1 hour"""
@@ -237,21 +335,22 @@ def cleanup_temp_files():
         temp_root = "/data/temp_snaps"
         if not os.path.exists(temp_root):
             return
-            
-        cutoff = time.time() - 3600 # 1 hour ago
-        
+
+        cutoff = time.time() - 3600  # 1 hour ago
+
         for dirpath, _, filenames in os.walk(temp_root):
             for f in filenames:
                 fp = os.path.join(dirpath, f)
                 try:
-                     if os.path.getmtime(fp) < cutoff:
-                         os.remove(fp)
-                         # Try removing empty dir? Maybe later.
+                    if os.path.getmtime(fp) < cutoff:
+                        os.remove(fp)
+                        # Try removing empty dir? Maybe later.
                 except OSError:
                     pass
         logger.info("Cleaned up temporary snapshots.")
     except Exception as e:
         logger.error(f"Error cleaning temp files: {e}")
+
 
 def run_cleanup(quota_only=False):
     """Main cleanup task to be run periodically. If quota_only=True, skips time-based retention."""
@@ -263,15 +362,28 @@ def run_cleanup(quota_only=False):
                 usage = shutil.disk_usage("/data")
                 percent_free = (usage.free / usage.total) * 100
                 if percent_free < 5.0:
-                    logger.warning(f"CRITICAL: Disk space is low ({percent_free:.2f}% free). Forcing emergency cleanup.")
+                    logger.warning(
+                        f"CRITICAL: Disk space is low ({percent_free:.2f}% free). Forcing emergency cleanup."
+                    )
                     # In emergency, we reduce EVERYTHING until we have 10% free
                     target_free_bytes = usage.total * 0.10
                     while usage.free < target_free_bytes:
-                        oldest = db.query(models.Event).order_by(models.Event.timestamp_start.asc()).first()
-                        if not oldest: break
-                        delete_event_media(oldest, db, reason="Emergency Disk Space")
+                        batch = (
+                            db.query(models.Event)
+                            .order_by(models.Event.timestamp_start.asc())
+                            .limit(100)
+                            .all()
+                        )
+                        if not batch:
+                            break
+                        for oldest in batch:
+                            if usage.free >= target_free_bytes:
+                                break
+                            delete_event_media(
+                                oldest, db, reason="Emergency Disk Space"
+                            )
+                            usage = shutil.disk_usage("/data")
                         db.commit()
-                        usage = shutil.disk_usage("/data")
             except Exception as disk_e:
                 logger.error(f"Error checking disk usage: {disk_e}")
 
@@ -279,45 +391,64 @@ def run_cleanup(quota_only=False):
             cameras = db.query(models.Camera).all()
             for camera in cameras:
                 # Quota enforcement (always runs)
-                cleanup_camera(db, camera, media_type=None, skip_time_retention=quota_only)
+                cleanup_camera(
+                    db, camera, media_type=None, skip_time_retention=quota_only
+                )
 
             # Priority 2: Enforce Profile-level Limits
             profiles = db.query(models.StorageProfile).all()
             for profile in profiles:
                 cleanup_profile(db, profile)
-            
+
             # Priority 3: Enforce Global Storage Limit
             max_global_str = get_setting(db, "max_global_storage_gb")
             max_global_gb = float(max_global_str) if max_global_str else 0
-            
+
             if max_global_gb > 0:
                 # Use DB-based metric to match UI "App Quota"
-                vibe_used_bytes = db.query(func.sum(models.Event.file_size)).scalar() or 0
+                vibe_used_bytes = (
+                    db.query(func.sum(models.Event.file_size)).scalar() or 0
+                )
                 current_used_gb = vibe_used_bytes / (1024**3)
-                
+
                 if current_used_gb > max_global_gb:
-                    logger.info(f"Global storage limit exceeded (App Quota): {current_used_gb:.2f}GB > {max_global_gb:.2f}GB. Cleaning up...")
+                    logger.info(
+                        f"Global storage limit exceeded (App Quota): {current_used_gb:.2f}GB > {max_global_gb:.2f}GB. Cleaning up..."
+                    )
                     target_gb = max_global_gb * 0.95
-                    
-                    max_iterations = 500 # Safety break
+
+                    max_iterations = 500  # Safety break
                     iterations = 0
                     while current_used_gb > target_gb and iterations < max_iterations:
                         iterations += 1
-                        oldest_event = db.query(models.Event).order_by(models.Event.timestamp_start.asc()).first()
-                        if not oldest_event: break
-                        
-                        size_gb = (oldest_event.file_size / (1024**3)) if oldest_event.file_size else 0.05
-                        success = delete_event_media(oldest_event, db, reason="Global Quota")
+                        batch = (
+                            db.query(models.Event)
+                            .order_by(models.Event.timestamp_start.asc())
+                            .limit(100)
+                            .all()
+                        )
+                        if not batch:
+                            break
+
+                        for oldest_event in batch:
+                            if current_used_gb <= target_gb:
+                                break
+                            size_gb = (
+                                (oldest_event.file_size / (1024**3))
+                                if oldest_event.file_size
+                                else 0.05
+                            )
+                            success = delete_event_media(
+                                oldest_event, db, reason="Global Quota"
+                            )
+                            if success:
+                                current_used_gb -= size_gb
+                            else:
+                                logger.error(
+                                    f"Failed to delete event {oldest_event.id} during global cleanup. Skipping."
+                                )
                         db.commit()
-                        
-                        if success:
-                            current_used_gb -= size_gb
-                        else:
-                            # If deletion fails, we skip this event to avoid infinite loop
-                            # (The event remains in DB and on disk, which is bad, but we can't do much)
-                            logger.error(f"Failed to delete event {oldest_event.id} during global cleanup. Skipping.")
-                            # We don't decrement current_used_gb, so iterations will eventually hit max_iterations
-            
+
             # Priority 4: Cleanup Temp Files (Only on full run)
             if not quota_only:
                 cleanup_temp_files()
@@ -325,10 +456,11 @@ def run_cleanup(quota_only=False):
         except Exception as e:
             logger.error(f"Error during cleanup: {e}")
 
+
 def storage_monitor_loop():
     """Background loop to run cleanup periodically"""
     last_full_run = 0
-    
+
     while True:
         try:
             now = time.time()
@@ -340,45 +472,63 @@ def storage_monitor_loop():
             if cleanup_enabled:
                 # Is it time for a full run (retention + quota)?
                 if now - last_full_run > (interval_hours * 3600):
-                    logger.info(f"Triggering scheduled FULL storage cleanup (Interval: {interval_hours}h)")
+                    logger.info(
+                        f"Triggering scheduled FULL storage cleanup (Interval: {interval_hours}h)"
+                    )
                     run_cleanup(quota_only=False)
                     last_full_run = now
                 else:
                     # Otherwise, just do a quick quota check every 10 minutes
                     run_cleanup(quota_only=True)
             else:
-                logger.debug("Automatic storage cleanup is DISABLED. Skipping periodic check.")
-            
+                logger.debug(
+                    "Automatic storage cleanup is DISABLED. Skipping periodic check."
+                )
+
             # Wait 10 minutes between checks
             time.sleep(600)
         except Exception as e:
             logger.error(f"Error in storage monitor loop: {e}")
-            time.sleep(300) # Wait 5 mins on error
+            time.sleep(300)  # Wait 5 mins on error
+
 
 def delete_camera_media(camera_id: int):
     """Delete all media files on disk for a specific camera"""
     try:
         with database.get_db_ctx() as db:
-            camera = db.query(models.Camera).filter(models.Camera.id == camera_id).first()
+            camera = (
+                db.query(models.Camera).filter(models.Camera.id == camera_id).first()
+            )
             if not camera:
                 # If camera already deleted from DB, we try the default path as fallback
                 camera_dir = f"/data/Camera{camera_id}"
                 if not os.path.exists(camera_dir):
-                     camera_dir = f"/data/{camera_id}"
+                    camera_dir = f"/data/{camera_id}"
             else:
-                storage_prefix = camera.storage_profile.path if camera.storage_profile else "/var/lib/vibe/recordings"
-                camera_dir = translate_path(os.path.join(storage_prefix, str(camera_id)))
+                storage_prefix = (
+                    camera.storage_profile.path
+                    if camera.storage_profile
+                    else "/var/lib/vibe/recordings"
+                )
+                camera_dir = translate_path(
+                    os.path.join(storage_prefix, str(camera_id))
+                )
 
         if os.path.exists(camera_dir):
             shutil.rmtree(camera_dir, ignore_errors=True)
             logger.info(f"Deleted media directory for camera {camera_id}: {camera_dir}")
         else:
-            logger.warning(f"Media directory for camera {camera_id} not found: {camera_dir}")
+            logger.warning(
+                f"Media directory for camera {camera_id} not found: {camera_dir}"
+            )
         return True
     except Exception as e:
         logger.error(f"Error deleting media for camera {camera_id}: {e}")
         return False
 
+
 def start_scheduler():
-    t = threading.Thread(target=storage_monitor_loop, daemon=True, name="StorageCleanupThread")
+    t = threading.Thread(
+        target=storage_monitor_loop, daemon=True, name="StorageCleanupThread"
+    )
     t.start()


### PR DESCRIPTION
💡 **What:** Optimized `backend/storage_service.py` to use `limit(100).all()` for fetching events to delete in batches instead of retrieving and deleting them one by one with `.first()`.
🎯 **Why:** Fetching and deleting one item at a time inside a while loop causes a severe N+1 query problem, creating massive database overhead during background storage cleanups. 
📊 **Impact:** Reduces database query overhead by up to 100x during intensive cleanup operations (like hitting global or per-camera quota limits) and groups deletes into fewer database transactions, significantly lowering database load.
🔬 **Measurement:** Verify performance by creating dummy events to fill quota limits and observing the execution time of `run_cleanup(quota_only=True)`. The query logs will show batched `SELECT` operations and fewer commits.

---
*PR created automatically by Jules for task [14190999587207266089](https://jules.google.com/task/14190999587207266089) started by @spupuz*