### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on OAuth endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,3 +36,8 @@
 **Vulnerability:** A timing attack vulnerability was identified in the webhook verification endpoint (`backend/routers/events.py`), where standard string comparison `==` or `!=` was used to compare the provided `X-Webhook-Secret` against the expected secret.
 **Learning:** Using standard string comparison operators allows an attacker to deduce the expected secret by measuring the time it takes for the comparison to fail.
 **Prevention:** Always use constant-time comparison functions like `hmac.compare_digest()` for security-sensitive string comparisons, such as API keys, tokens, or webhook secrets. Also, remember to encode strings to bytes before comparing if there's a chance they could contain Unicode characters.
+
+## 2025-06-30 - Fix Missing Rate Limiting on OAuth Endpoints
+**Vulnerability:** The OAuth endpoints in `backend/routers/oauth.py` (`/login`, `/callback`, `/unlink`, `/logout`) lacked rate limiting entirely. While standard authentication endpoints were protected, this omission left the OAuth flows vulnerable to brute force and denial of service attacks.
+**Learning:** When adding new authentication or integration endpoints (like OAuth), it is critical to ensure they inherit the same level of protection (such as rate limiting) as the core local authentication flows.
+**Prevention:** Always verify that the `@limiter.limit()` decorator is applied to newly introduced authentication/authorization endpoints. Furthermore, when adding `slowapi` rate limiting decorators to FastAPI endpoints, explicitly ensure the function signature includes the `request: Request` parameter, as `slowapi` relies on it to extract the client IP via `get_remote_address`.

--- a/backend/routers/oauth.py
+++ b/backend/routers/oauth.py
@@ -5,10 +5,12 @@ import database
 import models
 import auth_service
 from authlib.integrations.starlette_client import OAuth
-import json
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
 router = APIRouter(prefix="/oauth", tags=["oauth"])
 
+limiter = Limiter(key_func=get_remote_address)
 oauth = OAuth()
 
 def get_oauth_client(db: Session):
@@ -43,6 +45,7 @@ def get_oauth_client(db: Session):
     return oauth.sso_provider
 
 @router.get("/login")
+@limiter.limit("10/minute")
 async def oauth_login(request: Request, db: Session = Depends(database.get_db)):
     client = get_oauth_client(db)
     base_url = str(request.base_url)
@@ -71,6 +74,7 @@ async def oauth_login(request: Request, db: Session = Depends(database.get_db)):
     return await client.authorize_redirect(request, str(redirect_uri))
 
 @router.get("/callback")
+@limiter.limit("10/minute")
 async def oauth_callback(request: Request, db: Session = Depends(database.get_db)):
     client = get_oauth_client(db)
     
@@ -169,13 +173,15 @@ async def oauth_callback(request: Request, db: Session = Depends(database.get_db
     return response
 
 @router.post("/unlink")
-def unlink_oauth(db: Session = Depends(database.get_db), current_user: models.User = Depends(auth_service.get_current_user)):
+@limiter.limit("5/minute")
+def unlink_oauth(request: Request, db: Session = Depends(database.get_db), current_user: models.User = Depends(auth_service.get_current_user)):
     current_user.oauth_subject_id = None
     current_user.auth_source = "local"
     db.commit()
     return {"message": "OAuth unlinked successfully"}
 
 @router.get("/logout")
+@limiter.limit("10/minute")
 async def oauth_logout(request: Request, db: Session = Depends(database.get_db)):
     """Redirect to the OAuth provider's end_session_endpoint if available."""
     try:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The authentication endpoints for the OAuth flow (`/login`, `/callback`, `/unlink`, and `/logout` in `backend/routers/oauth.py`) were completely missing rate limiting. This stood in contrast to the local authentication endpoints, which were protected.
🎯 **Impact:** Without rate limiting, the OAuth flow was highly susceptible to automated abuse, including brute-force login attempts, token exhaustion, and potential Denial of Service (DoS) attacks targeting the SSO provider integration.
🔧 **Fix:** Imported `slowapi`'s `Limiter` and `get_remote_address` into the OAuth router. Applied standard `@limiter.limit` decorators (`10/minute` and `5/minute`) to the critical endpoints and injected the necessary `request: Request` parameter into the `unlink_oauth` signature to allow proper IP extraction.
✅ **Verification:** Verified by ensuring the backend linter and formatters (`ruff`) pass successfully, and executed the backend test suite (`pytest`) to guarantee zero regressions across the codebase.

---
*PR created automatically by Jules for task [6034908803705553587](https://jules.google.com/task/6034908803705553587) started by @spupuz*