### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility to group selection

### DIFF
--- a/frontend/src/components/GroupsManager.jsx
+++ b/frontend/src/components/GroupsManager.jsx
@@ -265,11 +265,22 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                         {/* Selection Checkbox */}
                         {user?.role === 'admin' && (
                             <div
-                                className={`absolute top-4 left-4 z-10 w-5 h-5 rounded border-2 flex items-center justify-center transition-all cursor-pointer ${selectedGroupIds.includes(group.id) ? 'bg-primary border-primary' : 'bg-background/80 border-border group-hover:border-primary/50'
+                                role="checkbox"
+                                aria-checked={selectedGroupIds.includes(group.id)}
+                                tabIndex={0}
+                                aria-label={t('timeline.select_group', 'Select group')}
+                                className={`absolute top-4 left-4 z-10 w-5 h-5 rounded border-2 flex items-center justify-center transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${selectedGroupIds.includes(group.id) ? 'bg-primary border-primary' : 'bg-background/80 border-border group-hover:border-primary/50'
                                     }`}
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     handleSelectGroup(group.id);
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        handleSelectGroup(group.id);
+                                    }
                                 }}
                             >
                                 {selectedGroupIds.includes(group.id) && <svg className="w-3.5 h-3.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={4} d="M5 13l4 4L19 7" /></svg>}


### PR DESCRIPTION
💡 What: Added keyboard accessibility and ARIA attributes to the group selection checkbox in `GroupsManager.jsx`.
🎯 Why: The custom `div` checkbox was previously inaccessible via keyboard and lacked screen reader context, preventing users who navigate via keyboard from selecting groups.
📸 Before/After: Before, keyboard navigation skipped the group checkbox entirely. After, the checkbox correctly receives focus, displays an outline (`focus-visible:ring-primary`), and can be toggled using Enter or Space keys.
♿ Accessibility: Added `role="checkbox"`, `aria-checked`, `tabIndex={0}`, `aria-label`, and an `onKeyDown` handler (Space/Enter) to support keyboard interaction and screen readers, bringing it inline with other custom checkboxes in the app.

---
*PR created automatically by Jules for task [4274747311898846922](https://jules.google.com/task/4274747311898846922) started by @spupuz*