### PR TITLE
⚡ Bolt: Optimize storage cleanup N+1 query bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,11 @@ When dealing with bulk deletions (e.g. `_cleanup_corrupted_videos` removing miss
 ## 2024-11-20 - Hoisting DB Queries from Import Loops
 **Learning:** Performing database queries like `crud.get_cameras()` inside loops (like tarball extraction processing) causes a massive O(N) performance bottleneck and N+1 query patterns.
 **Action:** Always hoist table-wide data retrieval operations outside of loops into O(1) structures like dictionaries or sets to check for existence/duplicates.
+
+## 2025-05-18 - Avoid full table scans when replacing multiple Count queries
+**Learning:** When attempting to consolidate multiple SQLAlchemy count queries into a single query using conditional aggregations (`func.sum(case(...))`), ensure you do not inadvertently remove `.filter()` clauses on indexed columns (like timestamps). Removing the `WHERE` clause forces a full table scan and causes severe performance regressions.
+**Action:** When trying to optimize multiple queries, only combine them if they share the same filter criteria, or if avoiding the full table scan is impossible. Otherwise, executing multiple queries that leverage database indexes is much faster than one query with a full table scan.
+
+## 2025-05-18 - Hoist database aggregates out of loops for large tables
+**Learning:** Performing `db.query(func.sum(...))` or other aggregates inside a loop (like `for camera in cameras:` in `run_cleanup`) causes an N+1 query issue. If the aggregate query does not depend on data changing within the loop, it's highly inefficient to run it repeatedly.
+**Action:** Hoist the aggregate query out of the loop using a SQL `GROUP BY` clause. Fetch all required sums or counts in a single O(1) query upfront, store them in a Python dictionary mapped by the grouping key (e.g., `camera_id`), and pass these pre-calculated values into the loop functions to prevent database hammering.

--- a/backend/storage_service.py
+++ b/backend/storage_service.py
@@ -107,6 +107,8 @@ def cleanup_camera(
     camera: models.Camera,
     media_type: str = None,
     skip_time_retention: bool = False,
+    precalc_movies_size: int = None,
+    precalc_pics_size: int = None,
 ):
     """
     Enforce storage limits and retention for a specific camera.
@@ -119,12 +121,15 @@ def cleanup_camera(
         and camera.max_storage_gb
         and camera.max_storage_gb > 0
     ):
-        total_movies_size = (
-            db.query(func.sum(models.Event.file_size))
-            .filter(models.Event.camera_id == camera.id, models.Event.type == "video")
-            .scalar()
-            or 0
-        )
+        if precalc_movies_size is not None:
+            total_movies_size = precalc_movies_size
+        else:
+            total_movies_size = (
+                db.query(func.sum(models.Event.file_size))
+                .filter(models.Event.camera_id == camera.id, models.Event.type == "video")
+                .scalar()
+                or 0
+            )
 
         movies_used_gb = total_movies_size / (1024**3)
         if movies_used_gb > camera.max_storage_gb:
@@ -162,14 +167,17 @@ def cleanup_camera(
         and camera.max_pictures_storage_gb
         and camera.max_pictures_storage_gb > 0
     ):
-        total_pics_size = (
-            db.query(func.sum(models.Event.file_size))
-            .filter(
-                models.Event.camera_id == camera.id, models.Event.type == "snapshot"
+        if precalc_pics_size is not None:
+            total_pics_size = precalc_pics_size
+        else:
+            total_pics_size = (
+                db.query(func.sum(models.Event.file_size))
+                .filter(
+                    models.Event.camera_id == camera.id, models.Event.type == "snapshot"
+                )
+                .scalar()
+                or 0
             )
-            .scalar()
-            or 0
-        )
 
         pics_used_gb = total_pics_size / (1024**3)
         if pics_used_gb > camera.max_pictures_storage_gb:
@@ -388,10 +396,31 @@ def run_cleanup(quota_only=False):
 
             # Priority 1: Enforce Per-Camera Quotas
             cameras = db.query(models.Camera).all()
+
+            # Pre-calculate sizes for all cameras in an O(1) query to avoid N+1 issues
+            sizes_query = db.query(
+                models.Event.camera_id,
+                models.Event.type,
+                func.sum(models.Event.file_size)
+            ).group_by(models.Event.camera_id, models.Event.type).all()
+
+            movies_sizes = {}
+            pics_sizes = {}
+            for cam_id, event_type, total_size in sizes_query:
+                if event_type == "video":
+                    movies_sizes[cam_id] = total_size or 0
+                elif event_type == "snapshot":
+                    pics_sizes[cam_id] = total_size or 0
+
             for camera in cameras:
                 # Quota enforcement (always runs)
                 cleanup_camera(
-                    db, camera, media_type=None, skip_time_retention=quota_only
+                    db,
+                    camera,
+                    media_type=None,
+                    skip_time_retention=quota_only,
+                    precalc_movies_size=movies_sizes.get(camera.id, 0),
+                    precalc_pics_size=pics_sizes.get(camera.id, 0)
                 )
 
             # Priority 2: Enforce Profile-level Limits


### PR DESCRIPTION
💡 What: Replaced individual `db.query(func.sum(models.Event.file_size))` calls inside the per-camera loop of `run_cleanup` with a single `GROUP BY` query executed beforehand. The precalculated sizes are now passed down to `cleanup_camera` as optional parameters.
🎯 Why: The `storage_monitor_loop` periodically runs `run_cleanup()`, which iterates over every single camera. Inside this loop, it was calculating the total size of video and snapshot events using database aggregates. This caused two database queries for every camera on every execution of the loop, leading to an N+1 query issue that degraded performance as the number of cameras grew.
📊 Impact: Reduces the number of database queries during a full storage cleanup pass from `(2 * number_of_cameras) + constant` down to just `1 + constant`. This achieves O(1) database query performance, significantly reducing database load and execution time for the cleanup service.
🔬 Measurement: Run the backend storage service tests (`PYTHONPATH=.:../engine pytest ../.github/scripts/test_crud.py`) to confirm no regressions. You can observe the SQL query logs to confirm only one query is executed for calculating the sizes instead of multiple per-camera queries.

---
*PR created automatically by Jules for task [1592877292568393485](https://jules.google.com/task/1592877292568393485) started by @spupuz*