### PR TITLE
⚡ Bolt: [performance improvement] O(1) bulk update for camera reordering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-26 - O(N) Updates in Reordering
+**Learning:** Iterating over a list of IDs and running `db.query().filter().update()` for each item creates an N+1 query bottleneck during bulk operations like camera reordering.
+**Action:** Use `db.bulk_update_mappings()` with a list of dictionaries to perform all updates in a single, batched O(1) database query.

--- a/backend/routers/cameras.py
+++ b/backend/routers/cameras.py
@@ -423,10 +423,12 @@ def reorder_cameras(
     current_user: models.User = Depends(auth_service.get_current_active_admin),
 ):
     """Reorder cameras in the database"""
-    for index, cam_id in enumerate(request.camera_ids):
-        db.query(models.Camera).filter(models.Camera.id == cam_id).update(
-            {models.Camera.sort_order: index}, synchronize_session=False
-        )
+    # ⚡ Bolt: Bulk update sort_order to avoid N+1 queries during drag-and-drop operations
+    mappings = [
+        {"id": cam_id, "sort_order": index}
+        for index, cam_id in enumerate(request.camera_ids)
+    ]
+    db.bulk_update_mappings(models.Camera, mappings)
     db.commit()
     return {"message": "Cameras reordered successfully"}
 


### PR DESCRIPTION
💡 What: Replaced the `for` loop inside `reorder_cameras` that executed individual `UPDATE` queries per camera with a single `db.bulk_update_mappings()` call.
🎯 Why: Drag-and-dropping to reorder items in a large grid of cameras was triggering an N+1 query problem, slowing down the backend response and needlessly locking SQLite.
📊 Impact: Reduces database update queries from O(N) (one per camera) to O(1) (a single batched transaction), leading to substantially faster reordering operations and reduced database contention.
🔬 Measurement: Run the `test_crud.py` tests. The `reorder_cameras` endpoint should now successfully apply the sort order using batch updates.

---
*PR created automatically by Jules for task [13823803756417924831](https://jules.google.com/task/13823803756417924831) started by @spupuz*