### PR TITLE
🎨 Palette: Localize title and aria-label attributes for better a11y

### DIFF
--- a/frontend/src/components/ApiTokenManager.jsx
+++ b/frontend/src/components/ApiTokenManager.jsx
@@ -155,7 +155,7 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                             </p>
                             <div className="flex items-center gap-2 mt-3 bg-background p-2 rounded border border-border">
                                 <code className="flex-1 font-mono text-sm break-all">{createdToken.token}</code>
-                                <Button size="sm" variant="ghost" title="Copy" aria-label="Copy" onClick={() => copyToClipboard(createdToken.token)}>
+                                <Button size="sm" variant="ghost" title={t('common.copy', 'Copy')} aria-label={t('common.copy', 'Copy')} onClick={() => copyToClipboard(createdToken.token)}>
                                     <Copy className="w-4 h-4" />
                                 </Button>
                             </div>
@@ -245,8 +245,8 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                                         <button
                                             onClick={() => setConfirmDelete({ isOpen: true, tokenId: apiToken.id })}
                                             className="p-2 hover:bg-red-100 text-red-500 rounded-lg transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center ml-auto"
-                                            title="Revoke Token"
-                                            aria-label="Revoke Token"
+                                            title={t('settings_apitokensettings.revoke_token', 'Revoke Token')}
+                                            aria-label={t('settings_apitokensettings.revoke_token', 'Revoke Token')}
                                         >
                                             <Trash2 className="w-5 h-5" />
                                         </button>
@@ -282,8 +282,8 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                                 <button
                                     onClick={() => setConfirmDelete({ isOpen: true, tokenId: apiToken.id })}
                                     className="p-3 bg-red-500/10 text-red-500 rounded-lg hover:bg-red-500/20 transition-colors min-w-[44px] min-h-[44px]"
-                                    title="Revoke Token"
-                                    aria-label="Revoke Token"
+                                    title={t('settings_apitokensettings.revoke_token', 'Revoke Token')}
+                                    aria-label={t('settings_apitokensettings.revoke_token', 'Revoke Token')}
                                 >
                                     <Trash2 className="w-5 h-5" />
                                 </button>

--- a/frontend/src/components/Cameras/BulkActionsBar.jsx
+++ b/frontend/src/components/Cameras/BulkActionsBar.jsx
@@ -15,36 +15,38 @@ export const BulkActionsBar = ({ selectedCameraIds, setSelectedCameraIds, handle
                     <button
                         onClick={() => setSelectedCameraIds([])}
                         className="sm:hidden px-3 py-1.5 text-xs font-semibold hover:bg-muted/50 rounded-lg transition-colors"
-                        aria-label="Clear"
+                        aria-label={t('common.clear', 'Clear')}
                     >
-                        Clear
+                        {t('common.clear', 'Clear')}
                     </button>
                 </div>
                 <div className="flex items-center justify-center gap-2 w-full sm:w-auto">
                     <button
                         onClick={() => setSelectedCameraIds([])}
                         className="hidden sm:block px-3 py-1.5 text-xs font-semibold hover:bg-muted/50 rounded-lg transition-colors"
-                        aria-label="Clear"
+                        aria-label={t('common.clear', 'Clear')}
                     >
-                        Clear
+                        {t('common.clear', 'Clear')}
                     </button>
                     <button
                         onClick={handleBulkExport}
                         className="flex-1 sm:flex-none px-3 sm:px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-xs font-bold rounded-lg transition-all flex items-center justify-center shadow-lg shadow-green-500/20 active:scale-95 whitespace-nowrap"
-                        aria-label="Export Selected"
+                        aria-label={t('cameras.export_selected', 'Export Selected')}
+                        title={t('cameras.export_selected', 'Export Selected')}
                     >
                         <Download className="w-3.5 h-3.5 sm:mr-1.5 mr-1" />
-                        <span className="hidden sm:inline">Export Selected</span>
-                        <span className="sm:hidden">Export</span>
+                        <span className="hidden sm:inline">{t('cameras.export_selected', 'Export Selected')}</span>
+                        <span className="sm:hidden">{t('common.export', 'Export')}</span>
                     </button>
                     <button
                         onClick={handleBulkDelete}
                         className="flex-1 sm:flex-none px-3 sm:px-4 py-2 bg-red-500 hover:bg-red-600 text-white text-xs font-bold rounded-lg transition-all flex items-center justify-center shadow-lg shadow-red-500/20 active:scale-95 whitespace-nowrap"
-                        aria-label="Delete Selected"
+                        aria-label={t('cameras.delete_selected', 'Delete Selected')}
+                        title={t('cameras.delete_selected', 'Delete Selected')}
                     >
                         <Trash2 className="w-3.5 h-3.5 sm:mr-1.5 mr-1" />
-                        <span className="hidden sm:inline">Delete Selected</span>
-                        <span className="sm:hidden">Delete</span>
+                        <span className="hidden sm:inline">{t('cameras.delete_selected', 'Delete Selected')}</span>
+                        <span className="sm:hidden">{t('common.delete', 'Delete')}</span>
                     </button>
                 </div>
             </div>

--- a/frontend/src/components/GroupsManager.jsx
+++ b/frontend/src/components/GroupsManager.jsx
@@ -294,7 +294,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                 </div>
 
                                 {/* Motion Toggle in Top Right */}
-                                <div className="flex items-center bg-muted/30 rounded-lg p-1 border border-border flex-shrink-0" title="Toggle Motion Detection for Group">
+                                <div className="flex items-center bg-muted/30 rounded-lg p-1 border border-border flex-shrink-0" title={t('timeline.toggle_motion', 'Toggle Motion Detection for Group')}>
                                     <div className="mr-2 flex items-center">
                                         {group.cameras.length > 0 && group.cameras.every(c => c.recording_mode !== 'Off') ? (
                                             <Play className="w-3 h-3 text-green-500 mr-1" />
@@ -348,7 +348,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                     <button
                                         onClick={() => setCopyingGroup(group)}
                                         className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 rounded-md transition-colors dark:bg-blue-900/20 dark:text-blue-400 dark:hover:bg-blue-900/40"
-                                        title="Copy Settings to all cameras in group"
+                                        title={t('timeline.copy_settings_title', 'Copy Settings to all cameras in group')}
                                     >
                                         <Copy className="w-3.5 h-3.5" />
                                         <span>{t('timeline.copy_settings', 'Copy Settings')}</span>
@@ -363,16 +363,16 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                         <button
                                             onClick={() => openManageModal(group)}
                                             className="p-2 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/40 rounded-lg transition-colors"
-                                            title="Edit Group"
-                                            aria-label="Edit Group"
+                                            title={t('timeline.edit_group', 'Edit Group')}
+                                            aria-label={t('timeline.edit_group', 'Edit Group')}
                                         >
                                             <Edit className="w-5 h-5" />
                                         </button>
                                         <button
                                             onClick={() => handleDeleteGroup(group.id)}
                                             className="p-2 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40 rounded-lg transition-colors"
-                                            title="Delete Group"
-                                            aria-label="Delete Group"
+                                            title={t('timeline.delete_group', 'Delete Group')}
+                                            aria-label={t('timeline.delete_group', 'Delete Group')}
                                         >
                                             <Trash2 className="w-5 h-5" />
                                         </button>

--- a/frontend/src/components/Timeline/BulkActionBar.jsx
+++ b/frontend/src/components/Timeline/BulkActionBar.jsx
@@ -55,8 +55,8 @@ export const BulkActionBar = ({
                     
                     <button
                         onClick={() => setSelectedIds(new Set())}
-                        title="Cancel"
-                        aria-label="Cancel selection"
+                        title={t('common.cancel', 'Cancel')}
+                        aria-label={t('timeline.cancel_selection', 'Cancel selection')}
                         className="p-2 sm:px-3 sm:py-1.5 hover:bg-white/10 rounded-xl transition-colors"
                     >
                         <X className="w-4 h-4 sm:hidden" />

--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Video, Image as ImageIcon, Download, Trash2, Camera, HardDrive, Brain } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -15,6 +16,7 @@ import { useAuth } from '../../contexts/AuthContext';
  * @param {Function} props.onDelete - Handler for single event deletion
  */
 export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMultiSelected, onToggleSelect, getMediaUrl, onDelete }) => {
+    const { t } = useTranslation();
     const { user } = useAuth();
     const [imgError, setImgError] = useState(false);
     const time = new Date(event.timestamp_start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -67,7 +69,7 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                         role="checkbox"
                         aria-checked={isMultiSelected}
                         tabIndex={0}
-                        aria-label="Select event"
+                        aria-label={t('timeline.select_event', 'Select event')}
                         className={`absolute top-2 left-2 z-20 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:opacity-100 rounded ${isMultiSelected ? 'opacity-100 scale-110' : 'opacity-0 group-hover:opacity-100'}`}
                         onClick={(e) => {
                             e.stopPropagation();
@@ -99,8 +101,8 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                         download
                         onClick={(e) => e.stopPropagation()}
                         className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors"
-                        title="Download"
-                        aria-label="Download"
+                        title={t('common.download', 'Download')}
+                        aria-label={t('common.download', 'Download')}
                     >
                         <Download className="w-3 h-3" />
                     </a>
@@ -113,8 +115,8 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                                 onDelete(event.id);
                             }}
                             className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors"
-                            title="Delete"
-                            aria-label="Delete"
+                            title={t('common.delete', 'Delete')}
+                            aria-label={t('common.delete', 'Delete')}
                         >
                             <Trash2 className="w-3 h-3" />
                         </button>

--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -85,7 +85,7 @@ export const EventPreview = ({
                                     }}
                                     onClick={(e) => e.stopPropagation()}
                                     className="ml-1 h-3.5 text-[9px] bg-transparent border-none focus:ring-0 cursor-pointer text-muted-foreground hover:text-foreground p-0 pr-1 pl-1"
-                                    title="Playback Order"
+                                    title={t('timeline.playback_order', 'Playback Order')}
                                 >
                                     <option value="desc" className="bg-card text-foreground">{t('timeline.newest_oldest', 'Newest → Oldest')}</option>
                                     <option value="asc" className="bg-card text-foreground">{t('timeline.oldest_newest', 'Oldest → Newest')}</option>
@@ -128,7 +128,7 @@ export const EventPreview = ({
                                 value={playbackSpeed}
                                 onChange={(e) => setPlaybackSpeed(Number(e.target.value))}
                                 className="bg-transparent text-xs font-black text-white/90 border-none focus:ring-0 cursor-pointer p-0 text-center w-8 appearance-none"
-                                title="Playback Speed"
+                                title={t('timeline.playback_speed', 'Playback Speed')}
                             >
                                 <option value={1} className="!bg-card !text-foreground">{t('timeline.1x', '1x')}</option>
                                 <option value={2} className="!bg-card !text-foreground">{t('timeline.2x', '2x')}</option>
@@ -176,7 +176,7 @@ export const EventPreview = ({
                                 value={autoplayDirection}
                                 onChange={(e) => setAutoplayDirection(e.target.value)}
                                 className="ml-1 h-5 text-[10px] bg-transparent border-none focus:ring-0 cursor-pointer text-muted-foreground hover:text-foreground p-0 pr-1 pl-1"
-                                title="Playback Order"
+                                title={t('timeline.playback_order', 'Playback Order')}
                             >
                                 <option value="desc" className="bg-card text-foreground">{t('timeline.newest_oldest', 'Newest → Oldest')}</option>
                                 <option value="asc" className="bg-card text-foreground">{t('timeline.oldest_newest', 'Oldest → Newest')}</option>
@@ -192,7 +192,7 @@ export const EventPreview = ({
                                 value={playbackSpeed}
                                 onChange={(e) => setPlaybackSpeed(Number(e.target.value))}
                                 className="bg-transparent text-xs font-bold text-foreground border-none focus:ring-0 cursor-pointer p-0 text-center w-12 appearance-none"
-                                title="Playback Speed"
+                                title={t('timeline.playback_speed', 'Playback Speed')}
                             >
                                 <option value={1} className="!bg-card !text-foreground">{t('timeline.1x', '1x')}</option>
                                 <option value={2} className="!bg-card !text-foreground">{t('timeline.2x', '2x')}</option>


### PR DESCRIPTION
💡 What: Replaced hardcoded string values for `title` and `aria-label` attributes with calls to the localization function (`t()`) across multiple components (GroupsManager, ApiTokenManager, EventCard, EventPreview, BulkActionBar, BulkActionsBar).
🎯 Why: To improve both accessibility (by ensuring screen reader text is properly localized) and overall localization coverage for standard UI elements (tooltips on buttons).
📸 Before/After: N/A (Internal text change, visual rendering remains identical unless language is switched)
♿ Accessibility: Ensures that `aria-label` attributes on icon-only buttons (like Edit, Delete, Copy) correctly reflect the user's chosen language, significantly improving the experience for international screen reader users.

---
*PR created automatically by Jules for task [4926912874301117360](https://jules.google.com/task/4926912874301117360) started by @spupuz*