### PR TITLE
🎨 Palette: Add focus visible styles for keyboard navigation

### DIFF
--- a/frontend/src/components/ui/FormControls.jsx
+++ b/frontend/src/components/ui/FormControls.jsx
@@ -42,7 +42,7 @@ export const Tooltip = ({ text, children }) => {
                 onMouseEnter={() => { updateCoords(); setShow(true); }}
                 onMouseLeave={() => setShow(false)}
                 onClick={() => { updateCoords(); setShow(!show); }}
-                className="ml-2 text-muted-foreground hover:text-primary transition-colors focus:outline-none"
+                className="ml-2 text-muted-foreground hover:text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
             >
                 <HelpCircle className="w-4 h-4" />
             </button>
@@ -180,7 +180,7 @@ export const InputField = ({ value, onChange, label, type = 'text', placeholder 
                         aria-label={showPassword ? "Hide password" : "Show password"}
                         aria-pressed={showPassword}
                         onClick={() => setShowPassword(!showPassword)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary transition-colors focus:outline-none"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
                     >
                         {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                     </button>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -680,7 +680,7 @@ export const Dashboard = () => {
                 </div>
                 <button
                     onClick={() => setShowWidgetModal(true)}
-                    className="p-2 hover:bg-muted rounded-lg transition-colors" aria-label={t('timeline.settings', 'Settings')}
+                    className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2" aria-label={t('timeline.settings', 'Settings')}
                 >
                     <Settings className="w-5 h-5 text-muted-foreground" />
                 </button>


### PR DESCRIPTION
💡 What: Added `focus-visible` ring styles to several key icon-only buttons (Tooltip trigger, InputField password toggle, Dashboard settings).
🎯 Why: Previously, these buttons only had `focus:outline-none` with no alternative visual focus indicator, making keyboard navigation inaccessible visually. 
📸 Before/After: See attached screenshot demonstrating the new focus ring on the password visibility toggle when using the Tab key.
♿ Accessibility: Improves WCAG compliance for focus indicators (2.4.7 Focus Visible) by ensuring keyboard users can see which interactive element has focus.

---
*PR created automatically by Jules for task [17516462796029636016](https://jules.google.com/task/17516462796029636016) started by @spupuz*