### PR TITLE
⚡ Bolt: Fix N+1 query issue in camera reordering

### DIFF
--- a/backend/routers/cameras.py
+++ b/backend/routers/cameras.py
@@ -423,11 +423,14 @@ def reorder_cameras(
     current_user: models.User = Depends(auth_service.get_current_active_admin),
 ):
     """Reorder cameras in the database"""
-    for index, cam_id in enumerate(request.camera_ids):
-        db.query(models.Camera).filter(models.Camera.id == cam_id).update(
-            {models.Camera.sort_order: index}, synchronize_session=False
-        )
-    db.commit()
+    # ⚡ Bolt: Bulk update to prevent N+1 queries when reordering multiple cameras
+    mappings = [
+        {"id": cam_id, "sort_order": index}
+        for index, cam_id in enumerate(request.camera_ids)
+    ]
+    if mappings:
+        db.bulk_update_mappings(models.Camera, mappings)
+        db.commit()
     return {"message": "Cameras reordered successfully"}
 
 


### PR DESCRIPTION
💡 What: Replaced a `for` loop executing sequential `db.query(...).update(...)` calls with a single `db.bulk_update_mappings(...)` call in the `/reorder` endpoint for cameras.

🎯 Why: The previous implementation created an N+1 query bottleneck. As the number of cameras being reordered increased, the number of database queries increased linearly, severely degrading performance and increasing SQLite lock contention.

📊 Impact: Reduces database queries during camera reordering from O(N) (where N is the number of cameras) to O(1) (a single bulk update query).

🔬 Measurement: Verified by reviewing the generated SQL queries and ensuring that the test suite passes successfully.

---
*PR created automatically by Jules for task [15775914979157549466](https://jules.google.com/task/15775914979157549466) started by @spupuz*