### PR TITLE
🎨 Palette: add aria-labels to bulk action bar buttons for better screen reader context

### DIFF
--- a/frontend/src/components/Timeline/BulkActionBar.jsx
+++ b/frontend/src/components/Timeline/BulkActionBar.jsx
@@ -38,6 +38,7 @@ export const BulkActionBar = ({
                 <div className="flex-1 flex items-center justify-end gap-1 sm:gap-4">
                     <button
                         onClick={handleSelectAll}
+                        aria-label={selectedIds.size === filteredEvents.length ? t('timeline.deselect_all', 'Deselect All') : t('timeline.select_all', 'Select All')}
                         className="px-1.5 py-1.5 hover:bg-white/10 rounded-xl transition-colors flex items-center gap-1 sm:gap-1.5"
                     >
                         {selectedIds.size === filteredEvents.length ? (
@@ -67,6 +68,7 @@ export const BulkActionBar = ({
                         <button
                             onClick={handleBulkDelete}
                             disabled={isBulkDeleting}
+                            aria-label={t('timeline.delete_selected', 'Delete {{count}} selected items', { count: selectedIds.size })}
                             className={`flex-shrink-0 px-3 py-2 sm:px-4 sm:py-2 bg-white text-primary hover:bg-white/90 rounded-xl text-xs sm:text-sm font-bold shadow-lg transition-all flex items-center gap-1.5 sm:gap-2 ${isBulkDeleting ? 'opacity-50 cursor-not-allowed' : 'active:scale-95'}`}
                         >
                             {isBulkDeleting ? (


### PR DESCRIPTION
💡 What:
Added dynamically evaluated `aria-label` attributes to the "Select/Deselect All" and "Delete" buttons in the Bulk Action Bar.

🎯 Why:
The text labels within these buttons are conditionally hidden on small screens (`hidden sm:inline`), leaving only an icon visible. Without an `aria-label`, screen reader users on mobile devices lack context for what the buttons do. Additionally, dynamically updating the delete count inside the `aria-label` provides clearer feedback for screen readers about the bulk action impact.

📸 Before/After:
Before: `button` with a `Trash2` icon and visually hidden "Delete X" text.
After: `button` with a `Trash2` icon, visually hidden text, and `aria-label="Delete 5 selected items"`.

♿ Accessibility:
Improved screen reader accessibility on mobile devices by ensuring that interactive elements that only display an icon provide explicit semantic context via `aria-label`.

---
*PR created automatically by Jules for task [8803615178305680733](https://jules.google.com/task/8803615178305680733) started by @spupuz*