### PR TITLE
⚡ Bolt: Fix N+1 query in camera reordering

### DIFF
--- a/backend/routers/cameras.py
+++ b/backend/routers/cameras.py
@@ -423,10 +423,12 @@ def reorder_cameras(
     current_user: models.User = Depends(auth_service.get_current_active_admin),
 ):
     """Reorder cameras in the database"""
-    for index, cam_id in enumerate(request.camera_ids):
-        db.query(models.Camera).filter(models.Camera.id == cam_id).update(
-            {models.Camera.sort_order: index}, synchronize_session=False
-        )
+    # Fix N+1 query: Update all cameras in a single O(1) query
+    mappings = [
+        {"id": cam_id, "sort_order": index}
+        for index, cam_id in enumerate(request.camera_ids)
+    ]
+    db.bulk_update_mappings(models.Camera, mappings)
     db.commit()
     return {"message": "Cameras reordered successfully"}
 


### PR DESCRIPTION
💡 What: Replaced a `for` loop executing individual `UPDATE` queries with a single `db.bulk_update_mappings()` call in the `reorder_cameras` endpoint.
🎯 Why: The original code caused an N+1 query problem, making a separate database roundtrip for each camera being reordered. This can cause significant latency and SQLite lock contention when reordering many cameras.
📊 Impact: Reduces database update roundtrips from O(N) to O(1), significantly improving the response time and efficiency of the reorder operation.
🔬 Measurement: Verify the change by benchmarking the `POST /reorder` endpoint with a large payload of `camera_ids` before and after the change, observing the reduced database execution time. The existing tests in `.github/scripts/` were also run and passed successfully.

---
*PR created automatically by Jules for task [10858275447892565244](https://jules.google.com/task/10858275447892565244) started by @spupuz*