### PR TITLE
🎨 Palette: Add ARIA labels to Bulk Action and Group Manager buttons

### DIFF
--- a/frontend/src/components/GroupsManager.jsx
+++ b/frontend/src/components/GroupsManager.jsx
@@ -234,6 +234,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                     {user?.role === 'admin' && groups.length > 0 && (
                         <button
                             onClick={handleSelectAllGroups}
+                            aria-label={selectedGroupIds.length === groups.length ? t('timeline.deselect_all', 'Deselect All') : t('timeline.select_all', 'Select All')}
                             className="flex items-center justify-center space-x-2 bg-muted hover:bg-secondary text-foreground px-3 h-8 rounded-lg transition-all whitespace-nowrap text-xs font-bold border border-border shadow-sm active:scale-95"
                         >
                             <div className={`w-3.5 h-3.5 rounded-sm border flex items-center justify-center transition-colors ${selectedGroupIds.length === groups.length ? 'bg-primary border-primary' : 'bg-background border-border'}`}>
@@ -347,6 +348,7 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                                 {user?.role === 'admin' && (
                                     <button
                                         onClick={() => setCopyingGroup(group)}
+                                        aria-label={t('timeline.copy_settings', 'Copy Settings')}
                                         className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 rounded-md transition-colors dark:bg-blue-900/20 dark:text-blue-400 dark:hover:bg-blue-900/40"
                                         title="Copy Settings to all cameras in group"
                                     >

--- a/frontend/src/components/Timeline/BulkActionBar.jsx
+++ b/frontend/src/components/Timeline/BulkActionBar.jsx
@@ -38,6 +38,7 @@ export const BulkActionBar = ({
                 <div className="flex-1 flex items-center justify-end gap-1 sm:gap-4">
                     <button
                         onClick={handleSelectAll}
+                        aria-label={selectedIds.size === filteredEvents.length ? t('timeline.deselect_all', 'Deselect All') : t('timeline.select_all', 'Select All')}
                         className="px-1.5 py-1.5 hover:bg-white/10 rounded-xl transition-colors flex items-center gap-1 sm:gap-1.5"
                     >
                         {selectedIds.size === filteredEvents.length ? (
@@ -67,6 +68,7 @@ export const BulkActionBar = ({
                         <button
                             onClick={handleBulkDelete}
                             disabled={isBulkDeleting}
+                            aria-label={t('timeline.delete_selected_items', `Delete {{count}} selected items`, { count: selectedIds.size })}
                             className={`flex-shrink-0 px-3 py-2 sm:px-4 sm:py-2 bg-white text-primary hover:bg-white/90 rounded-xl text-xs sm:text-sm font-bold shadow-lg transition-all flex items-center gap-1.5 sm:gap-2 ${isBulkDeleting ? 'opacity-50 cursor-not-allowed' : 'active:scale-95'}`}
                         >
                             {isBulkDeleting ? (


### PR DESCRIPTION
💡 What: Added missing `aria-label`s to action buttons in `BulkActionBar.jsx` and `GroupsManager.jsx`.
🎯 Why: Improves screen reader accessibility by providing clear context for interactive elements.
📸 Before/After: Visuals unchanged; screen reader output improved.
♿ Accessibility: Screen reader users will now understand the purpose of "Select All", "Copy Settings", and "Delete" bulk actions.

---
*PR created automatically by Jules for task [6071293672953190359](https://jules.google.com/task/6071293672953190359) started by @spupuz*