### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in webhook URL validation

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -3,11 +3,12 @@ import socket
 import ipaddress
 from urllib.parse import urlparse
 
+
 def is_safe_webhook_url(url: str) -> bool:
     """Check if a webhook URL is safe from SSRF attacks."""
     try:
         parsed = urlparse(url)
-        if parsed.scheme not in ('http', 'https'):
+        if parsed.scheme not in ("http", "https"):
             return False
 
         hostname = parsed.hostname
@@ -21,16 +22,26 @@ def is_safe_webhook_url(url: str) -> bool:
         # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
         # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
         # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
-        if ip_obj.is_link_local or ip_obj.is_multicast:
+        # We also block loopback (127.0.0.1) and unspecified (0.0.0.0) to prevent internal service SSRF.
+        if (
+            ip_obj.is_link_local
+            or ip_obj.is_multicast
+            or ip_obj.is_loopback
+            or ip_obj.is_unspecified
+        ):
             return False
 
         return True
     except Exception:
         return False
 
+
 def mask_url(text: str) -> str:
     """Mask credentials in RTSP/HTTP URLs for safe logging."""
-    if not text: return ""
+    if not text:
+        return ""
     # Redact credentials in URLs (rtsp://user:pass@host)
     # Supports both standard and those with special characters in the login/password
-    return re.sub(r'([a-z0-9]+://[^:]+:)([^@]+)(@)', r'\1*****\3', text, flags=re.IGNORECASE)
+    return re.sub(
+        r"([a-z0-9]+://[^:]+:)([^@]+)(@)", r"\1*****\3", text, flags=re.IGNORECASE
+    )


### PR DESCRIPTION
* 🚨 **Severity:** HIGH
* 💡 **Vulnerability:** The `is_safe_webhook_url` function failed to block loopback (`127.0.0.1`, `localhost`) and unspecified (`0.0.0.0`) IP addresses, making the application vulnerable to Server-Side Request Forgery (SSRF) against internal services on the backend container.
* 🎯 **Impact:** An attacker could potentially bypass SSRF protections and use the application's webhook functionality to probe or interact with internal APIs, databases, or local development services running on `localhost` or `0.0.0.0`.
* 🔧 **Fix:** Added explicit checks for `is_loopback` and `is_unspecified` to the `is_safe_webhook_url` function using the `ipaddress` module to ensure these critical internal IP ranges are blocked.
* ✅ **Verification:** Wrote and ran a Python snippet to test that `127.0.0.1`, `0.0.0.0`, and `localhost` return `False`. Ran the existing backend tests in `.github/scripts/test_settings_service.py` to ensure no functionality broke. Also passed standard formatting checks via `ruff`.

---
*PR created automatically by Jules for task [7496340555628197852](https://jules.google.com/task/7496340555628197852) started by @spupuz*