### PR TITLE
⚡ Bolt: Resolve N+1 query in bulk camera export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-07-26 - Health Check N+1 Optimization
 **Learning:** In periodic backend tasks involving iterations over all active cameras (like `check_camera_health`), processing each camera individually using standard `camera_id` lookups triggers O(N) database reads.
 **Action:** Always fetch the bulk collection of entities outside the loop and update helper functions to accept the fully resolved entity object rather than an ID to eliminate redundant lazy-loaded database queries.
+## 2024-05-15 - N+1 optimization in Bulk Export Endpoints
+**Learning:** In bulk export operations (like `export_bulk_cameras`), iterating through a list of IDs and fetching each entity individually creates an N+1 query bottleneck. While `selectinload` is used in `get_cameras`, it's not leveraged if fetching each entity independently.
+**Action:** Created `get_cameras_by_ids` which leverages `selectinload` for relationships (like `groups`, `storage_profile`) and uses a bulk `.in_()` query to fetch all relevant entities in a single O(1) query before iterating.

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -15,6 +15,12 @@ def get_cameras(db: Session, skip: int = 0, limit: int = 100):
         selectinload(models.Camera.storage_profile)
     ).order_by(models.Camera.sort_order.asc(), models.Camera.id.asc()).offset(skip).limit(limit).all()
 
+def get_cameras_by_ids(db: Session, camera_ids: list[int]):
+    return db.query(models.Camera).options(
+        selectinload(models.Camera.groups),
+        selectinload(models.Camera.storage_profile)
+    ).filter(models.Camera.id.in_(camera_ids)).all()
+
 def get_camera_by_rtsp_url(db: Session, rtsp_url: str):
     return db.query(models.Camera).filter(models.Camera.rtsp_url == rtsp_url).first()
 

--- a/backend/routers/cameras.py
+++ b/backend/routers/cameras.py
@@ -690,14 +690,15 @@ def export_bulk_cameras(
     """Export selected cameras settings as JSON"""
     export_data = []
 
-    for cam_id in camera_ids:
-        cam = crud.get_camera(db, cam_id)
-        if cam is not None:
-            cam_data = jsonable_encoder(schemas.CameraCreate.model_validate(cam))
-            cam_data["groups"] = [g.name for g in cam.groups]
-            if cam.storage_profile:
-                cam_data["storage_profile_name"] = cam.storage_profile.name
-            export_data.append(cam_data)
+    # ⚡ Bolt: Fetch all requested cameras in a single O(1) query instead of O(N) queries inside the loop
+    cameras = crud.get_cameras_by_ids(db, camera_ids)
+
+    for cam in cameras:
+        cam_data = jsonable_encoder(schemas.CameraCreate.model_validate(cam))
+        cam_data["groups"] = [g.name for g in cam.groups]
+        if cam.storage_profile:
+            cam_data["storage_profile_name"] = cam.storage_profile.name
+        export_data.append(cam_data)
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     return Response(


### PR DESCRIPTION
💡 What: Refactored `export_bulk_cameras` in `backend/routers/cameras.py` to use a new `get_cameras_by_ids` helper in `backend/crud.py` that utilizes `selectinload` for relationships (like `groups`, `storage_profile`) in a single bulk O(1) query.
🎯 Why: The original implementation in `export_bulk_cameras` iterated over a list of camera IDs and fetched each camera one-by-one from the database, leading to an O(N) database N+1 query bottleneck.
📊 Impact: Reduces DB queries for bulk export operations from O(N) to O(1), improving response times significantly for large camera exports.
🔬 Measurement: Verified with `test_crud.py` tests passing and code changes adhering to formatting and linting rules. The codebase's test suite explicitly checks that the N+1 behavior doesn't return regressions.

---
*PR created automatically by Jules for task [943572883972472349](https://jules.google.com/task/943572883972472349) started by @spupuz*