### PR TITLE
🎨 Palette: Add keyboard focus indicators to form control buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-27 - Added Focus States for Form Control Icon Buttons
+**Learning:** Certain custom icon-only UI elements (like form tooltips and password show/hide buttons) have `focus:outline-none` set without a `focus-visible` fallback, rendering them completely invisible to keyboard-only and screen reader users when navigating.
+**Action:** When creating or fixing custom form elements, always ensure `focus:outline-none` is paired with accessible fallbacks like `focus-visible:ring-2 focus-visible:ring-primary rounded-sm` to maintain a visual focus indicator for keyboard navigation.

--- a/frontend/src/components/ui/FormControls.jsx
+++ b/frontend/src/components/ui/FormControls.jsx
@@ -42,7 +42,7 @@ export const Tooltip = ({ text, children }) => {
                 onMouseEnter={() => { updateCoords(); setShow(true); }}
                 onMouseLeave={() => setShow(false)}
                 onClick={() => { updateCoords(); setShow(!show); }}
-                className="ml-2 text-muted-foreground hover:text-primary transition-colors focus:outline-none"
+                className="ml-2 text-muted-foreground hover:text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
             >
                 <HelpCircle className="w-4 h-4" />
             </button>
@@ -180,7 +180,7 @@ export const InputField = ({ value, onChange, label, type = 'text', placeholder 
                         aria-label={showPassword ? "Hide password" : "Show password"}
                         aria-pressed={showPassword}
                         onClick={() => setShowPassword(!showPassword)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary transition-colors focus:outline-none"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
                     >
                         {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                     </button>


### PR DESCRIPTION
💡 **What:** Added keyboard focus indicators (`focus-visible`) to icon-only buttons in `FormControls.jsx` (specifically the Tooltip trigger and the show/hide password toggle).
🎯 **Why:** These buttons had `focus:outline-none` set to remove default browser outlines, making them completely invisible when navigated via keyboard. This was a critical accessibility regression.
📸 **Before/After:** Before, pressing Tab over these elements showed no visual feedback. After, a primary-colored focus ring appears around the icon.
♿ **Accessibility:** Restores visual focus indication for keyboard-only and screen reader users navigating forms, meeting basic a11y focus state requirements.

---
*PR created automatically by Jules for task [3760554034145438410](https://jules.google.com/task/3760554034145438410) started by @spupuz*