### PR TITLE
⚡ Bolt: [performance improvement] Offload blocking DB calls to threadpool in async routes

### DIFF
--- a/backend/routers/cameras.py
+++ b/backend/routers/cameras.py
@@ -32,6 +32,10 @@ import logging
 from urllib.parse import urlparse
 from typing import Optional, List, Any
 import datetime
+import jwt
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import StreamingResponse
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +59,47 @@ def extract_host(url: str) -> Optional[str]:
             url = "rtsp://" + url
         parsed = urlparse(url)
         return parsed.hostname
-    except:
+    except Exception:
         return None
+
+
+def _verify_camera_access_sync(token: str, camera_id: int) -> dict:
+    """Thread-safe synchronous wrapper for verifying camera access and extracting user."""
+    db = database.SessionLocal()
+    try:
+        # Decode JWT token
+        try:
+            payload = jwt.decode(token, auth_service.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+            username: str = payload.get("sub")
+            if not username:
+                return {"status": 401, "detail": "Invalid token"}
+        except jwt.PyJWTError:
+            return {"status": 401, "detail": "Invalid token"}
+
+        # Get User
+        user = db.query(models.User).filter(models.User.username == username).first()
+        if user is None:
+            return {"status": 401, "detail": "User not found"}
+
+        # Get Camera
+        db_camera = crud.get_camera(db, camera_id=camera_id)
+        if db_camera is None:
+            return {"status": 404, "detail": "Camera not found"}
+
+        # Check access
+        if user.role == "viewer" and user.restrict_camera_access:
+            allowed_ids = crud.get_allowed_camera_ids_for_user(db, user.id, permission="view")
+            if allowed_ids is not None and camera_id not in allowed_ids:
+                return {"status": 403, "detail": "Not authorized to view this camera"}
+
+        return {
+            "status": 200,
+            "user_role": user.role,
+            "user_username": user.username,
+            "user_id": user.id,
+        }
+    finally:
+        db.close()
 
 
 def sanitize_rtsp_url(url: str) -> str:
@@ -431,10 +474,6 @@ def reorder_cameras(
     return {"message": "Cameras reordered successfully"}
 
 
-from fastapi.responses import StreamingResponse
-import httpx
-
-
 @router.websocket("/{camera_id}/ws")
 async def websocket_camera_stream(websocket: WebSocket, camera_id: int):
     """Proxy raw H.264 PyAV packets from engine to the frontend via WebSockets"""
@@ -448,19 +487,11 @@ async def websocket_camera_stream(websocket: WebSocket, camera_id: int):
         return
 
     try:
-        with database.get_db_ctx() as db:
-            user = await auth_service.get_user_from_token(token, db)
-            db_camera = crud.get_camera(db, camera_id=camera_id)
-            if db_camera is None:
-                await websocket.close(code=1008)
-                return
-            if user.role == "viewer" and user.restrict_camera_access:
-                allowed_ids = crud.get_allowed_camera_ids_for_user(
-                    db, user.id, permission="view"
-                )
-                if allowed_ids is not None and camera_id not in allowed_ids:
-                    await websocket.close(code=1008)
-                    return
+        access_info = await run_in_threadpool(_verify_camera_access_sync, token, camera_id)
+        if access_info["status"] != 200:
+            logging.error(f"WS Auth Fail: {access_info['detail']} for camera {camera_id}")
+            await websocket.close(code=1008)
+            return
     except Exception as e:
         logging.error(f"WS Auth Fail: Invalid token for camera {camera_id} - {str(e)}")
         await websocket.close(code=1008)
@@ -495,8 +526,6 @@ async def websocket_camera_stream(websocket: WebSocket, camera_id: int):
             await websocket.close()
         except Exception:
             pass
-        except:
-            pass
 
 
 @router.get("/{camera_id}/frame")
@@ -514,35 +543,21 @@ async def get_camera_frame(
         )
         raise HTTPException(status_code=401, detail="Missing media authentication")
 
-    # Verify authentication and camera existence
-    db = database.SessionLocal()
-    try:
-        user = await auth_service.get_user_from_token(media_token, db)
-        db_camera = crud.get_camera(db, camera_id=camera_id)
-        if db_camera is None:
-            raise HTTPException(status_code=404, detail="Camera not found")
+    # Verify authentication and camera existence (using thread-safe sync wrapper)
+    access_info = await run_in_threadpool(_verify_camera_access_sync, media_token, camera_id)
+    if access_info["status"] != 200:
+        raise HTTPException(status_code=access_info["status"], detail=access_info["detail"])
 
-        if user.role == "viewer" and user.restrict_camera_access:
-            allowed_ids = crud.get_allowed_camera_ids_for_user(
-                db, user.id, permission="view"
+    frame_url = f"http://engine:8000/cameras/{camera_id}/frame"
+
+    if raw:
+        # Security: Only admins can view unmasked (raw) frames
+        if access_info["user_role"] == "admin":
+            frame_url += "?raw=true"
+        else:
+            logging.warning(
+                f"Security: Non-admin user {access_info['user_username']} (ID: {access_info['user_id']}) attempted to access raw frame for camera {camera_id}"
             )
-            if allowed_ids is not None and camera_id not in allowed_ids:
-                raise HTTPException(
-                    status_code=403, detail="Not authorized to view this camera"
-                )
-
-        frame_url = f"http://engine:8000/cameras/{camera_id}/frame"
-
-        if raw:
-            # Security: Only admins can view unmasked (raw) frames
-            if user.role == "admin":
-                frame_url += "?raw=true"
-            else:
-                logging.warning(
-                    f"Security: Non-admin user {user.username} (ID: {user.id}) attempted to access raw frame for camera {camera_id}"
-                )
-    finally:
-        db.close()
 
     try:
         async with httpx.AsyncClient(timeout=2.0) as client:
@@ -575,20 +590,9 @@ async def stream_camera(camera_id: int, request: Request, token: Optional[str] =
         raise HTTPException(status_code=401, detail="Missing media authentication")
 
     try:
-        with database.get_db_ctx() as db:
-            user = await auth_service.get_user_from_token(media_token, db)
-            db_camera = crud.get_camera(db, camera_id=camera_id)
-            if db_camera is None:
-                raise HTTPException(status_code=404, detail="Camera not found")
-
-            if user.role == "viewer" and user.restrict_camera_access:
-                allowed_ids = crud.get_allowed_camera_ids_for_user(
-                    db, user.id, permission="view"
-                )
-                if allowed_ids is not None and camera_id not in allowed_ids:
-                    raise HTTPException(
-                        status_code=403, detail="Not authorized to view this camera"
-                    )
+        access_info = await run_in_threadpool(_verify_camera_access_sync, media_token, camera_id)
+        if access_info["status"] != 200:
+            raise HTTPException(status_code=access_info["status"], detail=access_info["detail"])
     except HTTPException:
         raise
     except Exception as e:
@@ -657,8 +661,6 @@ def export_all_cameras(
     cameras = crud.get_cameras(db)
     export_data = []
 
-    fields_to_exclude = {"id", "created_at", "groups", "events"}
-
     for cam in cameras:
         # Pydantic v2 validation (excludes relationships and system fields like ID automatically)
         cam_data = jsonable_encoder(schemas.CameraCreate.model_validate(cam))
@@ -716,8 +718,6 @@ def export_single_camera(
     cam = crud.get_camera(db, camera_id)
     if cam is None:
         raise HTTPException(status_code=404, detail="Camera not found")
-
-    fields_to_exclude = {"id", "created_at", "groups", "events"}
 
     # Use schema to serialize without relationships
     filtered_data = jsonable_encoder(schemas.CameraCreate.model_validate(cam))

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -16,6 +16,8 @@ import auth_service
 import datetime
 import logging
 import time
+import jwt
+from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +26,47 @@ router = APIRouter(
     tags=["events"],
     responses={404: {"description": "Not found"}},
 )
+
+def _verify_event_access_sync(token: str, event_id: int) -> dict:
+    """Thread-safe synchronous wrapper for verifying event download access."""
+    db = database.SessionLocal()
+    try:
+        # Decode JWT token
+        try:
+            payload = jwt.decode(token, auth_service.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+            username: str = payload.get("sub")
+            if not username:
+                return {"status": 401, "detail": "Invalid token"}
+        except jwt.PyJWTError:
+            return {"status": 401, "detail": "Invalid token"}
+
+        # Get User
+        user = db.query(models.User).filter(models.User.username == username).first()
+        if user is None:
+            return {"status": 401, "detail": "User not found"}
+
+        # Get Event
+        event = db.query(models.Event).filter(models.Event.id == event_id).first()
+        if not event:
+            return {"status": 404, "detail": "Event not found"}
+
+        # Check access
+        if user.role == "viewer" and user.restrict_camera_access:
+            allowed_ids = crud.get_allowed_camera_ids_for_user(db, user.id, permission="replay")
+            if allowed_ids is not None and event.camera_id not in allowed_ids:
+                return {"status": 403, "detail": "Not authorized to download this event"}
+
+        if not event.file_path:
+            return {"status": 404, "detail": "No file associated with this event"}
+
+        return {
+            "status": 200,
+            "file_path": event.file_path,
+            "event_type": event.type
+        }
+    finally:
+        db.close()
+
 
 def _send_telegram_notification(
     camera,
@@ -309,7 +352,8 @@ def send_notifications(camera_id: int, event_type: str, details: dict):
 
             # Fix path mapping (Internal Container -> Backend /data volume)
             def map_path(p):
-                if not p: return None
+                if not p:
+                    return None
                 if p.startswith("/var/lib/motion"):
                     return p.replace("/var/lib/motion", "/data", 1)
                 elif p.startswith("/var/lib/vibe/recordings"):
@@ -765,24 +809,13 @@ async def download_event(event_id: int, request: Request, token: Optional[str] =
     if not media_token:
         raise HTTPException(status_code=401, detail="Missing media authentication")
 
-    with database.get_db_ctx() as db:
-        user = await auth_service.get_user_from_token(media_token, db)
-        event = db.query(models.Event).filter(models.Event.id == event_id).first()
-        if not event:
-            raise HTTPException(status_code=404, detail="Event not found")
+    access_result = await run_in_threadpool(_verify_event_access_sync, media_token, event_id)
+    if access_result["status"] != 200:
+        raise HTTPException(status_code=access_result["status"], detail=access_result["detail"])
 
-        if user.role == "viewer" and user.restrict_camera_access:
-            allowed_ids = crud.get_allowed_camera_ids_for_user(db, user.id, permission="replay")
-            if allowed_ids is not None and event.camera_id not in allowed_ids:
-                raise HTTPException(status_code=403, detail="Not authorized to download this event")
+    file_path = access_result["file_path"]
+    event_type = access_result["event_type"]
 
-        if not event.file_path:
-            raise HTTPException(status_code=404, detail="No file associated with this event")
-
-        file_path = event.file_path
-        event_type = event.type
-
-    # db is closed here
     # Convert DB path to backend filesystem path
     prefix = "/var/lib/motion"
     backend_prefix = "/data"


### PR DESCRIPTION
💡 What:
Replaced direct synchronous SQLAlchemy database calls inside `async def` endpoints (`websocket_camera_stream`, `get_camera_frame`, `stream_camera` in `backend/routers/cameras.py` and `download_event` in `backend/routers/events.py`) with thread-safe synchronous wrapper functions executed via `fastapi.concurrency.run_in_threadpool`.

🎯 Why:
In FastAPI, asynchronous endpoints run on the main event loop. Performing synchronous, blocking database queries within these routes stalled the event loop, causing poor concurrency and degraded performance for all other incoming API requests.

📊 Impact:
Significantly improves concurrency and API responsiveness under load. Eliminates main event loop blocking caused by slow database queries in media proxy routes, enabling FastAPI to handle more simultaneous connections without freezing.

🔬 Measurement:
Start the backend, simulate multiple simultaneous requests to these async media endpoints, and observe that other unrelated API requests are no longer blocked and respond quickly.

---
*PR created automatically by Jules for task [3055477659192366336](https://jules.google.com/task/3055477659192366336) started by @spupuz*