### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limit on setup and weak random

### DIFF
--- a/.github/scripts/test_auth_setup_rate_limit.py
+++ b/.github/scripts/test_auth_setup_rate_limit.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import Request
+from main import app
+import database
+from unittest.mock import MagicMock
+from datetime import datetime, timezone
+import crud
+import models
+
+client = TestClient(app)
+
+def test_setup_admin_rate_limit(mocker):
+    # Set Limiter enabled
+    app.state.limiter.enabled = True
+
+    # Mock database
+    mock_db = mocker.MagicMock()
+    mock_query = mocker.MagicMock()
+    mock_db.query.return_value = mock_query
+    # simulate existing_user is None
+    mock_query.first.return_value = None
+    app.dependency_overrides[database.get_db] = lambda: mock_db
+
+    mock_user = models.User(
+        id=1,
+        username="test",
+        email="test@test.com",
+        role="admin",
+        language="en",
+        auth_source="local",
+        oauth_subject_id=None,
+        avatar_path=None,
+        created_at=datetime.now(timezone.utc),
+        is_2fa_enabled=False
+    )
+
+    mocker.patch("crud.create_user", return_value=mock_user)
+
+    # Send 6 requests quickly
+    for i in range(10):
+        # We need to make sure the endpoint is accessed exactly as in production
+        # In main.py, it's just app.include_router(auth.router), which has prefix="/auth"
+        response = client.post("/auth/setup", json={"username": "test", "password": "password", "email": "test@test.com"})
+        if response.status_code == 429:
+            break
+
+    assert response.status_code == 429

--- a/.github/scripts/test_auth_setup_rate_limit.py
+++ b/.github/scripts/test_auth_setup_rate_limit.py
@@ -3,20 +3,21 @@ from fastapi.testclient import TestClient
 from fastapi import Request
 from main import app
 import database
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from datetime import datetime, timezone
 import crud
 import models
 
 client = TestClient(app)
 
-def test_setup_admin_rate_limit(mocker):
+@patch("crud.create_user")
+def test_setup_admin_rate_limit(mock_create_user):
     # Set Limiter enabled
     app.state.limiter.enabled = True
 
     # Mock database
-    mock_db = mocker.MagicMock()
-    mock_query = mocker.MagicMock()
+    mock_db = MagicMock()
+    mock_query = MagicMock()
     mock_db.query.return_value = mock_query
     # simulate existing_user is None
     mock_query.first.return_value = None
@@ -35,7 +36,7 @@ def test_setup_admin_rate_limit(mocker):
         is_2fa_enabled=False
     )
 
-    mocker.patch("crud.create_user", return_value=mock_user)
+    mock_create_user.return_value = mock_user
 
     # Send 6 requests quickly
     for i in range(10):

--- a/.github/scripts/test_engine_main.py
+++ b/.github/scripts/test_engine_main.py
@@ -4,8 +4,11 @@ from unittest.mock import patch, MagicMock
 import copy
 
 # We will need to set PYTHONPATH=engine when running this test
-import sys, os; sys.path.insert(0, os.path.abspath("engine")); from main import app, GLOBAL_CONFIG
-
+import sys, os
+sys.path.insert(0, os.path.abspath("engine"))
+if "main" in sys.modules:
+    del sys.modules["main"]
+from main import app, GLOBAL_CONFIG
 client = TestClient(app)
 
 @pytest.fixture(autouse=True)

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2024-05-30 - [Missing Rate Limit on Setup]
+**Vulnerability:** The `/setup` endpoint in `backend/routers/auth.py`, used to create the first admin user, was publicly accessible without rate limiting.
+**Learning:** Even one-time use initialization endpoints that check for existing setup completion (`if existing_user: raise HTTPException`) are vulnerable to brute-force or DoS attacks during the initial setup window if unconstrained.
+**Prevention:** Ensure all public-facing endpoints, including initial setup routes, use `@limiter.limit` and explicitly require the `request: Request` parameter for slowapi to function.
+
+## 2024-05-30 - [Weak PRNG for Identifiers]
+**Vulnerability:** Weak PRNG (`Math.random()`) used for generating unique Toast IDs in the frontend.
+**Learning:** Using `Math.random` combined with string truncation (`substr(2, 9)`) for ID generation is prone to collisions and is not cryptographically secure, even for UI components.
+**Prevention:** Always use `crypto.randomUUID()` to guarantee uniqueness and strong entropy when generating client-side unique identifiers.

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -362,7 +362,8 @@ async def me_from_cookie(request: Request, response: Response, db: Session = Dep
     }
 
 @router.post("/setup", response_model=schemas.User)
-def setup_admin(user: schemas.UserCreate, db: Session = Depends(database.get_db)):
+@limiter.limit("5/minute")
+def setup_admin(request: Request, user: schemas.UserCreate, db: Session = Depends(database.get_db)):
     """
     Initial setup endpoint to create the first admin user.
     Only allows creation if no users exist in the database.

--- a/frontend/src/contexts/ToastContext.jsx
+++ b/frontend/src/contexts/ToastContext.jsx
@@ -7,7 +7,7 @@ export const ToastProvider = ({ children }) => {
     const [toasts, setToasts] = useState([]);
 
     const showToast = useCallback((message, type = 'success', duration = 4000) => {
-        const id = Math.random().toString(36).substr(2, 9);
+        const id = crypto.randomUUID();
         setToasts((prev) => [...prev, { id, message, type }]);
 
         setTimeout(() => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/setup` endpoint lacked rate limiting, exposing the system to brute force/DoS attacks during initialization. Additionally, the frontend used a weak PRNG (`Math.random()`) for ID generation.
🎯 Impact: Attackers could flood the server during the initial setup window, and weak UI IDs could lead to client-side collisions.
🔧 Fix: Added `@limiter.limit("5/minute")` to the `/setup` endpoint. Replaced `Math.random()` with `crypto.randomUUID()` in `ToastContext.jsx`.
✅ Verification: Added a pytest script to confirm the rate limit returns a 429 response. Validated frontend builds correctly with `crypto.randomUUID()`.

---
*PR created automatically by Jules for task [17705189726606869508](https://jules.google.com/task/17705189726606869508) started by @spupuz*