### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF Vulnerability in Webhook Validation

### DIFF
--- a/.github/scripts/test_settings_service.py
+++ b/.github/scripts/test_settings_service.py
@@ -45,7 +45,7 @@ def test_validate_setting_valid():
     validate_setting("mqtt_port", "65535")
 
     # notify_webhook_url
-    validate_setting("notify_webhook_url", "http://localhost:8080/webhook")
+    validate_setting("notify_webhook_url", "http://192.168.1.5:8080/webhook")
     validate_setting("notify_webhook_url", "https://example.com/api")
     validate_setting("notify_webhook_url", "")  # empty value is allowed for clearing
 
@@ -122,7 +122,6 @@ def test_validate_webhook_url_valid_ip():
     # Should not raise any exception
     _validate_webhook_url("http://192.168.1.100")
     _validate_webhook_url("https://8.8.8.8:8080/webhook")
-    _validate_webhook_url("http://127.0.0.1")
 
 def test_validate_webhook_url_invalid_format():
     """Test invalid URL format."""

--- a/backend/settings_service.py
+++ b/backend/settings_service.py
@@ -29,8 +29,8 @@ def _validate_webhook_url(value: str):
                 ip_addr = ipaddress.ip_address(socket.gethostbyname(host))
             except Exception:
                 return
-        if ip_addr.is_loopback or ip_addr.is_private or ip_addr.is_reserved or ip_addr.is_link_local:
-            pass
+        if ip_addr.is_loopback or ip_addr.is_unspecified or ip_addr.is_link_local or ip_addr.is_multicast:
+            raise ValueError(f'Webhook cannot target internal/restricted IP ranges ({ip_addr})')
     except Exception as e:
         if isinstance(e, ValueError): raise e
         raise ValueError(f'Invalid or unreachable URL: {str(e)}')

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -18,10 +18,10 @@ def is_safe_webhook_url(url: str) -> bool:
         ip = socket.gethostbyname(hostname)
         ip_obj = ipaddress.ip_address(ip)
 
-        # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
+        # Block link-local (169.254.x.x), multicast, loopback, and unspecified to prevent SSRF against cloud metadata and sensitive internal addresses.
         # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
         # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
-        if ip_obj.is_link_local or ip_obj.is_multicast:
+        if ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_loopback or ip_obj.is_unspecified:
             return False
 
         return True


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) via webhook validation. The previous logic explicitly allowed webhook URLs targeting loopback (127.0.0.1) and unspecified (0.0.0.0) addresses using a `pass` statement, which failed to mitigate SSRF.
🎯 **Impact:** An attacker could craft a payload to target the loopback address or unspecified address, bypassing SSRF protections and potentially accessing sensitive internal services or triggering local vulnerabilities.
🔧 **Fix:** 
- Updated `backend/utils.py` to explicitly block `is_loopback` and `is_unspecified` IP properties.
- Updated `backend/settings_service.py` to explicitly raise a `ValueError` for loopback, unspecified, link-local, and multicast IP addresses, while continuing to intentionally permit valid private IP addresses (e.g. for Home Assistant integrations).
- Updated the unit tests (`.github/scripts/test_settings_service.py`) to correctly reflect these validation rules, changing test cases from loopback to a valid private IP address.
✅ **Verification:** Verified via test scripts and passing the existing pytest test suite for `test_settings_service.py` and `test_engine_utils.py`.

---
*PR created automatically by Jules for task [6198272469815401877](https://jules.google.com/task/6198272469815401877) started by @spupuz*