### PR TITLE
⚡ Bolt: [performance improvement] optimize health service camera query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-07-26 - Health Check N+1 Optimization
 **Learning:** In periodic backend tasks involving iterations over all active cameras (like `check_camera_health`), processing each camera individually using standard `camera_id` lookups triggers O(N) database reads.
 **Action:** Always fetch the bulk collection of entities outside the loop and update helper functions to accept the fully resolved entity object rather than an ID to eliminate redundant lazy-loaded database queries.
+## 2024-07-31 - Background Task Query Optimization
+**Learning:** Reusing API-oriented CRUD functions (like `crud.get_cameras`) that eagerly load relationships (`selectinload`) in tight background loops (like `health_service`) causes unnecessary memory bloat and database load.
+**Action:** Create lightweight queries (e.g., `crud.get_active_cameras_lightweight`) tailored to fetch only the required models for performance-sensitive background tasks.

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -3,67 +3,103 @@ from sqlalchemy.orm import Session, selectinload
 import models
 import schemas
 
+
 def get_camera(db: Session, camera_id: int):
     return db.query(models.Camera).filter(models.Camera.id == camera_id).first()
+
 
 def get_cameras(db: Session, skip: int = 0, limit: int = 100):
     # Performance Optimization: Use selectinload to eagerly load the groups and
     # storage_profile relationships. This prevents N+1 queries and avoids the Cartesian
     # product explosion that joinedload would cause for collections.
-    return db.query(models.Camera).options(
-        selectinload(models.Camera.groups),
-        selectinload(models.Camera.storage_profile)
-    ).order_by(models.Camera.sort_order.asc(), models.Camera.id.asc()).offset(skip).limit(limit).all()
+    return (
+        db.query(models.Camera)
+        .options(
+            selectinload(models.Camera.groups),
+            selectinload(models.Camera.storage_profile),
+        )
+        .order_by(models.Camera.sort_order.asc(), models.Camera.id.asc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def get_active_cameras_lightweight(db: Session):
+    # ⚡ Bolt: Fetch active cameras without eagerly loading relationships for performance-sensitive background tasks
+    return db.query(models.Camera).filter(models.Camera.is_active == True).all()  # noqa: E712
+
 
 def get_camera_by_rtsp_url(db: Session, rtsp_url: str):
     return db.query(models.Camera).filter(models.Camera.rtsp_url == rtsp_url).first()
 
+
 def create_camera(db: Session, camera: schemas.CameraCreate):
     create_data = camera.dict()
     # Convert list to JSON string for the DB column only if it's a list
-    if 'ai_object_types' in create_data and isinstance(create_data['ai_object_types'], list):
+    if "ai_object_types" in create_data and isinstance(
+        create_data["ai_object_types"], list
+    ):
         import json
-        create_data['ai_object_types'] = json.dumps(create_data['ai_object_types'])
-        
+
+        create_data["ai_object_types"] = json.dumps(create_data["ai_object_types"])
+
     db_camera = models.Camera(**create_data)
     db.add(db_camera)
     db.commit()
     db.refresh(db_camera)
     return db_camera
 
+
 def update_camera(db: Session, camera_id: int, camera: schemas.CameraCreate):
     db_camera = db.query(models.Camera).filter(models.Camera.id == camera_id).first()
     if db_camera:
         update_data = camera.dict()
         # Convert list to JSON string for the DB column only if it's a list
-        if 'ai_object_types' in update_data and isinstance(update_data['ai_object_types'], list):
+        if "ai_object_types" in update_data and isinstance(
+            update_data["ai_object_types"], list
+        ):
             import json
-            update_data['ai_object_types'] = json.dumps(update_data['ai_object_types'])
-            
+
+            update_data["ai_object_types"] = json.dumps(update_data["ai_object_types"])
+
         for key, value in update_data.items():
             setattr(db_camera, key, value)
         db.commit()
         db.refresh(db_camera)
     return db_camera
 
+
 def delete_camera(db: Session, camera_id: int):
     from sqlalchemy.orm import joinedload
-    db_camera = db.query(models.Camera).options(
-        joinedload(models.Camera.storage_profile),
-        joinedload(models.Camera.groups)
-    ).filter(models.Camera.id == camera_id).first()
+
+    db_camera = (
+        db.query(models.Camera)
+        .options(
+            joinedload(models.Camera.storage_profile), joinedload(models.Camera.groups)
+        )
+        .filter(models.Camera.id == camera_id)
+        .first()
+    )
     if db_camera:
         db.delete(db_camera)
         db.commit()
     return db_camera
 
+
 def bulk_delete_cameras(db: Session, camera_ids: list[int]) -> int:
     # ⚡ Bolt: Use selectinload instead of joinedload for collections and IN query for O(1) query performance
     from sqlalchemy.orm import selectinload
-    cameras = db.query(models.Camera).options(
-        selectinload(models.Camera.storage_profile),
-        selectinload(models.Camera.groups)
-    ).filter(models.Camera.id.in_(camera_ids)).all()
+
+    cameras = (
+        db.query(models.Camera)
+        .options(
+            selectinload(models.Camera.storage_profile),
+            selectinload(models.Camera.groups),
+        )
+        .filter(models.Camera.id.in_(camera_ids))
+        .all()
+    )
 
     deleted_count = 0
     for camera in cameras:
@@ -75,7 +111,15 @@ def bulk_delete_cameras(db: Session, camera_ids: list[int]) -> int:
 
     return deleted_count
 
-def get_events(db: Session, skip: int = 0, limit: int = 100, camera_id: int = None, type: str = None, date: str = None):
+
+def get_events(
+    db: Session,
+    skip: int = 0,
+    limit: int = 100,
+    camera_id: int = None,
+    type: str = None,
+    date: str = None,
+):
     query = db.query(models.Event)
     if camera_id:
         query = query.filter(models.Event.camera_id == camera_id)
@@ -86,21 +130,28 @@ def get_events(db: Session, skip: int = 0, limit: int = 100, camera_id: int = No
         # Use a range to handle timezone correctly
         # Use a range to handle timezone correctly
         from zoneinfo import ZoneInfo
-        
+
         # Get local timezone from env or default to Europe/Rome as per docker-compose
         import os
-        tz_name = os.environ.get('TZ', 'Europe/Rome')
+
+        tz_name = os.environ.get("TZ", "Europe/Rome")
         local_tz = ZoneInfo(tz_name)
-        
+
         # Parse date and set to start of day in local timezone
-        naive_start = datetime.strptime(date, '%Y-%m-%d')
+        naive_start = datetime.strptime(date, "%Y-%m-%d")
         start_date = naive_start.replace(tzinfo=local_tz)
         end_date = start_date + timedelta(days=1)
-        
+
         query = query.filter(models.Event.timestamp_start >= start_date)
         query = query.filter(models.Event.timestamp_start < end_date)
-        
-    return query.order_by(models.Event.timestamp_start.desc()).offset(skip).limit(limit).all()
+
+    return (
+        query.order_by(models.Event.timestamp_start.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
 
 def create_event(db: Session, event: schemas.EventCreate):
     db_event = models.Event(**event.dict())
@@ -109,6 +160,7 @@ def create_event(db: Session, event: schemas.EventCreate):
     db.refresh(db_event)
     return db_event
 
+
 def delete_event(db: Session, event_id: int):
     db_event = db.query(models.Event).filter(models.Event.id == event_id).first()
     if db_event:
@@ -116,119 +168,176 @@ def delete_event(db: Session, event_id: int):
         db.commit()
     return db_event
 
+
 def get_user(db: Session, user_id: int):
     return db.query(models.User).filter(models.User.id == user_id).first()
+
 
 def get_user_by_username(db: Session, username: str):
     return db.query(models.User).filter(models.User.username == username).first()
 
+
 def get_user_by_email(db: Session, email: str):
     return db.query(models.User).filter(models.User.email == email).first()
+
 
 def get_users(db: Session, skip: int = 0, limit: int = 100):
     # Performance Optimization: Use selectinload to eagerly load camera_accesses
     # and group_accesses relationships. This resolves an N+1 query issue during
     # API serialization, significantly reducing DB query count from O(N) to O(1).
-    return db.query(models.User).options(
-        selectinload(models.User.camera_accesses).selectinload(models.UserCameraAccess.camera),
-        selectinload(models.User.group_accesses).selectinload(models.UserGroupAccess.group)
-    ).offset(skip).limit(limit).all()
+    return (
+        db.query(models.User)
+        .options(
+            selectinload(models.User.camera_accesses).selectinload(
+                models.UserCameraAccess.camera
+            ),
+            selectinload(models.User.group_accesses).selectinload(
+                models.UserGroupAccess.group
+            ),
+        )
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
 
 def create_user(db: Session, user: schemas.UserCreate):
     # Import here to avoid circular dependency
     import auth_service
+
     hashed_password = auth_service.get_password_hash(user.password)
     db_user = models.User(
         username=user.username,
         email=user.email,
         hashed_password=hashed_password,
         role=user.role,
-        restrict_camera_access=user.restrict_camera_access
+        restrict_camera_access=user.restrict_camera_access,
     )
     db.add(db_user)
     db.commit()
-    
+
     if user.camera_accesses is not None:
         db_user.camera_accesses = []
         for acc in user.camera_accesses:
-            db_user.camera_accesses.append(models.UserCameraAccess(
-                camera_id=acc.id, can_view=acc.can_view, can_replay=acc.can_replay, can_control=acc.can_control
-            ))
+            db_user.camera_accesses.append(
+                models.UserCameraAccess(
+                    camera_id=acc.id,
+                    can_view=acc.can_view,
+                    can_replay=acc.can_replay,
+                    can_control=acc.can_control,
+                )
+            )
     elif user.allowed_camera_ids:
         db_user.camera_accesses = []
-        cameras = db.query(models.Camera).filter(models.Camera.id.in_(user.allowed_camera_ids)).all()
+        cameras = (
+            db.query(models.Camera)
+            .filter(models.Camera.id.in_(user.allowed_camera_ids))
+            .all()
+        )
         for c in cameras:
             db_user.camera_accesses.append(models.UserCameraAccess(camera_id=c.id))
-            
+
     if user.group_accesses is not None:
         db_user.group_accesses = []
         for acc in user.group_accesses:
-            db_user.group_accesses.append(models.UserGroupAccess(
-                group_id=acc.id, can_view=acc.can_view, can_replay=acc.can_replay, can_control=acc.can_control
-            ))
+            db_user.group_accesses.append(
+                models.UserGroupAccess(
+                    group_id=acc.id,
+                    can_view=acc.can_view,
+                    can_replay=acc.can_replay,
+                    can_control=acc.can_control,
+                )
+            )
     elif user.allowed_group_ids:
         db_user.group_accesses = []
-        groups = db.query(models.CameraGroup).filter(models.CameraGroup.id.in_(user.allowed_group_ids)).all()
+        groups = (
+            db.query(models.CameraGroup)
+            .filter(models.CameraGroup.id.in_(user.allowed_group_ids))
+            .all()
+        )
         for g in groups:
             db_user.group_accesses.append(models.UserGroupAccess(group_id=g.id))
-        
+
     db.commit()
     db.refresh(db_user)
     return db_user
+
 
 def update_user(db: Session, user_id: int, user: schemas.UserUpdate):
     db_user = db.query(models.User).filter(models.User.id == user_id).first()
     if not db_user:
         return None
-        
+
     db_user.username = user.username
     db_user.email = user.email
     db_user.role = user.role
     db_user.restrict_camera_access = user.restrict_camera_access
-    
+
     # OAuth
-    if hasattr(user, 'oauth_enabled') and user.oauth_enabled is not None:
+    if hasattr(user, "oauth_enabled") and user.oauth_enabled is not None:
         db_user.oauth_enabled = user.oauth_enabled
-    if hasattr(user, 'oauth_subject_id'):
+    if hasattr(user, "oauth_subject_id"):
         db_user.oauth_subject_id = user.oauth_subject_id
-    if hasattr(user, 'auth_source') and user.auth_source:
+    if hasattr(user, "auth_source") and user.auth_source:
         db_user.auth_source = user.auth_source
-    
+
     # Note: password update is handled separately, but if provided here, we could update it.
     if user.password and user.password != "********":
         import auth_service
+
         db_user.hashed_password = auth_service.get_password_hash(user.password)
-        
+
     # Update relations
     if user.camera_accesses is not None:
         db_user.camera_accesses = []
         for acc in user.camera_accesses:
-            db_user.camera_accesses.append(models.UserCameraAccess(
-                camera_id=acc.id, can_view=acc.can_view, can_replay=acc.can_replay, can_control=acc.can_control
-            ))
+            db_user.camera_accesses.append(
+                models.UserCameraAccess(
+                    camera_id=acc.id,
+                    can_view=acc.can_view,
+                    can_replay=acc.can_replay,
+                    can_control=acc.can_control,
+                )
+            )
     elif user.allowed_camera_ids is not None:
         db_user.camera_accesses = []
-        cameras = db.query(models.Camera).filter(models.Camera.id.in_(user.allowed_camera_ids)).all()
+        cameras = (
+            db.query(models.Camera)
+            .filter(models.Camera.id.in_(user.allowed_camera_ids))
+            .all()
+        )
         for c in cameras:
             db_user.camera_accesses.append(models.UserCameraAccess(camera_id=c.id))
-            
+
     if user.group_accesses is not None:
         db_user.group_accesses = []
         for acc in user.group_accesses:
-            db_user.group_accesses.append(models.UserGroupAccess(
-                group_id=acc.id, can_view=acc.can_view, can_replay=acc.can_replay, can_control=acc.can_control
-            ))
+            db_user.group_accesses.append(
+                models.UserGroupAccess(
+                    group_id=acc.id,
+                    can_view=acc.can_view,
+                    can_replay=acc.can_replay,
+                    can_control=acc.can_control,
+                )
+            )
     elif user.allowed_group_ids is not None:
         db_user.group_accesses = []
-        groups = db.query(models.CameraGroup).filter(models.CameraGroup.id.in_(user.allowed_group_ids)).all()
+        groups = (
+            db.query(models.CameraGroup)
+            .filter(models.CameraGroup.id.in_(user.allowed_group_ids))
+            .all()
+        )
         for g in groups:
             db_user.group_accesses.append(models.UserGroupAccess(group_id=g.id))
-        
+
     db.commit()
     db.refresh(db_user)
     return db_user
 
-def get_allowed_camera_ids_for_user(db: Session, user_id: int, permission: str = "view") -> list[int] | None:
+
+def get_allowed_camera_ids_for_user(
+    db: Session, user_id: int, permission: str = "view"
+) -> list[int] | None:
     """Returns a list of camera IDs the user is allowed to access with the required permission, or None if they have full access."""
     user = get_user(db, user_id)
     if not user or user.role == "admin" or not user.restrict_camera_access:
@@ -240,22 +349,31 @@ def get_allowed_camera_ids_for_user(db: Session, user_id: int, permission: str =
     camera_ids = set()
 
     # 1. Collect explicit camera IDs
-    direct_ids = db.query(models.UserCameraAccess.camera_id).filter(
-        models.UserCameraAccess.user_id == user_id,
-        getattr(models.UserCameraAccess, f"can_{permission}").is_(True)
-    ).all()
+    direct_ids = (
+        db.query(models.UserCameraAccess.camera_id)
+        .filter(
+            models.UserCameraAccess.user_id == user_id,
+            getattr(models.UserCameraAccess, f"can_{permission}").is_(True),
+        )
+        .all()
+    )
 
     for (cid,) in direct_ids:
         camera_ids.add(cid)
 
     # 2. Collect camera IDs from groups with the required permission
-    group_camera_ids = db.query(models.CameraGroupAssociation.camera_id).join(
-        models.UserGroupAccess,
-        models.UserGroupAccess.group_id == models.CameraGroupAssociation.group_id
-    ).filter(
-        models.UserGroupAccess.user_id == user_id,
-        getattr(models.UserGroupAccess, f"can_{permission}").is_(True)
-    ).all()
+    group_camera_ids = (
+        db.query(models.CameraGroupAssociation.camera_id)
+        .join(
+            models.UserGroupAccess,
+            models.UserGroupAccess.group_id == models.CameraGroupAssociation.group_id,
+        )
+        .filter(
+            models.UserGroupAccess.user_id == user_id,
+            getattr(models.UserGroupAccess, f"can_{permission}").is_(True),
+        )
+        .all()
+    )
 
     for (cid,) in group_camera_ids:
         camera_ids.add(cid)
@@ -270,6 +388,7 @@ def delete_user(db: Session, user_id: int):
         db.commit()
     return db_user
 
+
 def update_user_password(db: Session, user_id: int, hashed_password: str):
     db_user = db.query(models.User).filter(models.User.id == user_id).first()
     if db_user:
@@ -278,18 +397,36 @@ def update_user_password(db: Session, user_id: int, hashed_password: str):
         db.refresh(db_user)
     return db_user
 
+
 # Groups
 def get_groups(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(models.CameraGroup).options(
-        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
-        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.storage_profile)
-    ).offset(skip).limit(limit).all()
+    return (
+        db.query(models.CameraGroup)
+        .options(
+            selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
+            selectinload(models.CameraGroup.cameras).selectinload(
+                models.Camera.storage_profile
+            ),
+        )
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
 
 def get_group(db: Session, group_id: int):
-    return db.query(models.CameraGroup).options(
-        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
-        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.storage_profile)
-    ).filter(models.CameraGroup.id == group_id).first()
+    return (
+        db.query(models.CameraGroup)
+        .options(
+            selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
+            selectinload(models.CameraGroup.cameras).selectinload(
+                models.Camera.storage_profile
+            ),
+        )
+        .filter(models.CameraGroup.id == group_id)
+        .first()
+    )
+
 
 def create_group(db: Session, group: schemas.CameraGroupCreate):
     db_group = models.CameraGroup(**group.dict())
@@ -298,16 +435,22 @@ def create_group(db: Session, group: schemas.CameraGroupCreate):
     db.refresh(db_group)
     return db_group
 
+
 def delete_group(db: Session, group_id: int):
-    db_group = db.query(models.CameraGroup).filter(models.CameraGroup.id == group_id).first()
+    db_group = (
+        db.query(models.CameraGroup).filter(models.CameraGroup.id == group_id).first()
+    )
     if db_group:
         db.delete(db_group)
         db.commit()
     return db_group
 
+
 def bulk_delete_groups(db: Session, group_ids: list[int]) -> int:
     # ⚡ Bolt: Fetch all groups in a single O(1) query instead of O(N) queries inside the loop
-    groups = db.query(models.CameraGroup).filter(models.CameraGroup.id.in_(group_ids)).all()
+    groups = (
+        db.query(models.CameraGroup).filter(models.CameraGroup.id.in_(group_ids)).all()
+    )
 
     deleted_count = 0
     for group in groups:
@@ -319,11 +462,12 @@ def bulk_delete_groups(db: Session, group_ids: list[int]) -> int:
 
     return deleted_count
 
+
 def update_group_cameras(db: Session, group_id: int, camera_ids: list[int]):
     db_group = get_group(db, group_id)
     if not db_group:
         return None
-    
+
     # Fetch cameras
     cameras = db.query(models.Camera).filter(models.Camera.id.in_(camera_ids)).all()
     db_group.cameras = cameras
@@ -331,14 +475,23 @@ def update_group_cameras(db: Session, group_id: int, camera_ids: list[int]):
     db.refresh(db_group)
     return db_group
 
+
 # API Tokens
-def create_api_token(db: Session, name: str, token_hash: str, user_id: int, expires_at: datetime = None):
+def create_api_token(
+    db: Session, name: str, token_hash: str, user_id: int, expires_at: datetime = None
+):
     """Create a new API token"""
-    db_token = models.ApiToken(name=name, token_hash=token_hash, created_by_user_id=user_id, expires_at=expires_at)
+    db_token = models.ApiToken(
+        name=name,
+        token_hash=token_hash,
+        created_by_user_id=user_id,
+        expires_at=expires_at,
+    )
     db.add(db_token)
     db.commit()
     db.refresh(db_token)
     return db_token
+
 
 def get_api_tokens(db: Session, user_id: int = None):
     """List all API tokens (optionally filtered by user)"""
@@ -347,9 +500,15 @@ def get_api_tokens(db: Session, user_id: int = None):
         query = query.filter(models.ApiToken.created_by_user_id == user_id)
     return query.all()
 
+
 def get_api_token_by_hash(db: Session, token_hash: str):
     """Find token by hash (for authentication)"""
-    return db.query(models.ApiToken).filter(models.ApiToken.token_hash == token_hash).first()
+    return (
+        db.query(models.ApiToken)
+        .filter(models.ApiToken.token_hash == token_hash)
+        .first()
+    )
+
 
 def update_token_last_used(db: Session, token_id: int):
     """Update last used timestamp"""
@@ -357,6 +516,7 @@ def update_token_last_used(db: Session, token_id: int):
     if token:
         token.last_used_at = datetime.now(timezone.utc)
         db.commit()
+
 
 def delete_api_token(db: Session, token_id: int):
     """Delete an API token"""
@@ -367,33 +527,55 @@ def delete_api_token(db: Session, token_id: int):
         return True
     return False
 
+
 # Recovery Codes
 def create_recovery_codes(db: Session, user_id: int, hashed_codes: list[str]):
-    codes = [models.RecoveryCode(user_id=user_id, code_hash=hash_val) for hash_val in hashed_codes]
+    codes = [
+        models.RecoveryCode(user_id=user_id, code_hash=hash_val)
+        for hash_val in hashed_codes
+    ]
     db.add_all(codes)
     db.commit()
 
+
 def get_recovery_codes(db: Session, user_id: int):
-    return db.query(models.RecoveryCode).filter(models.RecoveryCode.user_id == user_id).all()
+    return (
+        db.query(models.RecoveryCode)
+        .filter(models.RecoveryCode.user_id == user_id)
+        .all()
+    )
+
 
 def delete_recovery_code(db: Session, code_id: int):
-    code = db.query(models.RecoveryCode).filter(models.RecoveryCode.id == code_id).first()
+    code = (
+        db.query(models.RecoveryCode).filter(models.RecoveryCode.id == code_id).first()
+    )
     if code:
         db.delete(code)
         db.commit()
         return True
     return False
 
+
 def delete_all_recovery_codes(db: Session, user_id: int):
-    db.query(models.RecoveryCode).filter(models.RecoveryCode.user_id == user_id).delete()
+    db.query(models.RecoveryCode).filter(
+        models.RecoveryCode.user_id == user_id
+    ).delete()
     db.commit()
+
 
 # Storage Profiles
 def get_storage_profile(db: Session, profile_id: int):
-    return db.query(models.StorageProfile).filter(models.StorageProfile.id == profile_id).first()
+    return (
+        db.query(models.StorageProfile)
+        .filter(models.StorageProfile.id == profile_id)
+        .first()
+    )
+
 
 def get_storage_profiles(db: Session, skip: int = 0, limit: int = 100):
     return db.query(models.StorageProfile).offset(skip).limit(limit).all()
+
 
 def create_storage_profile(db: Session, profile: schemas.StorageProfileCreate):
     db_profile = models.StorageProfile(**profile.dict())
@@ -402,8 +584,15 @@ def create_storage_profile(db: Session, profile: schemas.StorageProfileCreate):
     db.refresh(db_profile)
     return db_profile
 
-def update_storage_profile(db: Session, profile_id: int, profile: schemas.StorageProfileCreate):
-    db_profile = db.query(models.StorageProfile).filter(models.StorageProfile.id == profile_id).first()
+
+def update_storage_profile(
+    db: Session, profile_id: int, profile: schemas.StorageProfileCreate
+):
+    db_profile = (
+        db.query(models.StorageProfile)
+        .filter(models.StorageProfile.id == profile_id)
+        .first()
+    )
     if db_profile:
         for key, value in profile.dict().items():
             setattr(db_profile, key, value)
@@ -411,14 +600,18 @@ def update_storage_profile(db: Session, profile_id: int, profile: schemas.Storag
         db.refresh(db_profile)
     return db_profile
 
+
 def delete_storage_profile(db: Session, profile_id: int):
-    db_profile = db.query(models.StorageProfile).filter(models.StorageProfile.id == profile_id).first()
+    db_profile = (
+        db.query(models.StorageProfile)
+        .filter(models.StorageProfile.id == profile_id)
+        .first()
+    )
     if db_profile:
         # Before deleting, nullify camera references
-        db.query(models.Camera).filter(models.Camera.storage_profile_id == profile_id).update(
-            {models.Camera.storage_profile_id: None},
-            synchronize_session=False
-        )
+        db.query(models.Camera).filter(
+            models.Camera.storage_profile_id == profile_id
+        ).update({models.Camera.storage_profile_id: None}, synchronize_session=False)
         db.delete(db_profile)
         db.commit()
     return db_profile

--- a/backend/health_service.py
+++ b/backend/health_service.py
@@ -140,7 +140,8 @@ async def check_camera_health():
                 with database.get_db_ctx() as db:
                     # Process each camera reported by engine
                     # Note: We only care about cameras that are supposed to be active
-                    cameras = crud.get_cameras(db)
+                    # ⚡ Bolt: Use optimized query to avoid N+1 query and memory bloat from eagerly loaded relationships
+                    cameras = crud.get_active_cameras_lightweight(db)
 
                     for camera in cameras:
                         await _fetch_and_update_health(db, engine_status, camera=camera)


### PR DESCRIPTION
💡 What: Created a lightweight query function `crud.get_active_cameras_lightweight` that fetches only active cameras without eagerly loading their relationships (groups and storage profiles), and updated `health_service.check_camera_health` to use it instead of the API-oriented `crud.get_cameras`.

🎯 Why: The previous implementation used `crud.get_cameras(db)` in a tight 10-second loop. This function uses `selectinload` to eagerly load related collections, which causes unnecessary memory bloat and database overhead for a background task that only needs the `Camera` model to check and update its status.

📊 Impact: Reduces memory footprint and database load in the background health check loop by avoiding the hydration and transmission of unnecessary relationship objects.

🔬 Measurement: Verified that tests pass via `pytest .github/scripts/test_health_service.py` to ensure zero regressions in the background loop logic.

---
*PR created automatically by Jules for task [16727385210100436354](https://jules.google.com/task/16727385210100436354) started by @spupuz*