### PR TITLE
⚡ Bolt: [performance improvement] Fix N+1 query in camera restoration

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -369,6 +369,15 @@ async def perform_restore(data: dict, db: Session):
         except: return None
 
     if "cameras" in data:
+        # Pre-fetch existing cameras to avoid O(N) database queries during loop
+        all_cams = db.query(models.Camera).all()
+        # Create an O(1) lookup dictionary mapping host -> camera
+        cams_by_host = {
+            get_host(c.rtsp_url): c
+            for c in all_cams
+            if c.rtsp_url and get_host(c.rtsp_url)
+        }
+
         for c in data["cameras"]:
             backup_id = c.get("id")
             rtsp_url = c.get("rtsp_url")
@@ -376,8 +385,7 @@ async def perform_restore(data: dict, db: Session):
             
             existing_cam = db.query(models.Camera).filter(models.Camera.id == backup_id).first()
             if not existing_cam and cam_host:
-                all_cams = db.query(models.Camera).all()
-                existing_cam = next((cam for cam in all_cams if get_host(cam.rtsp_url) == cam_host), None)
+                existing_cam = cams_by_host.get(cam_host)
             
             if not existing_cam:
                 id_conflict = db.query(models.Camera).filter(models.Camera.id == backup_id).first()


### PR DESCRIPTION
💡 What: Modified `perform_restore` in `backend/routers/settings.py` to hoist an O(N) query for `models.Camera` outside the `data["cameras"]` restoration loop. The query results are now cached in an O(1) dictionary mapping hosts to cameras.
🎯 Why: Previously, when restoring cameras from a backup where a camera ID was not found, the code executed `db.query(models.Camera).all()` for *each* camera in the loop to match by host. This caused an N+1 query explosion, significantly degrading performance and database load when restoring large backups.
📊 Impact: Eliminates redundant database reads. Reduces the database queries from O(N * M) (where N is the number of cameras in the database and M is the number of cameras being restored) to O(1) during the backup matching process. Memory usage remains comparable as the query was fetching all objects anyway.
🔬 Measurement: Verified the removal of the N+1 query from the loop. Ran the `test_settings_service.py` and `test_crud.py` tests successfully via pytest to ensure no functional regressions occurred.

---
*PR created automatically by Jules for task [3188787961516176947](https://jules.google.com/task/3188787961516176947) started by @spupuz*