### PR TITLE
🎨 Palette: Add keyboard focus-visible styles to navigation and action buttons

### DIFF
--- a/frontend/src/components/Cameras/BulkActionsBar.jsx
+++ b/frontend/src/components/Cameras/BulkActionsBar.jsx
@@ -14,7 +14,7 @@ export const BulkActionsBar = ({ selectedCameraIds, setSelectedCameraIds, handle
                     <p className="text-[10px] text-muted-foreground uppercase font-bold tracking-wider hidden sm:block">{t('cameras.bulk_actions', 'Bulk Actions')}</p>
                     <button
                         onClick={() => setSelectedCameraIds([])}
-                        className="sm:hidden px-3 py-1.5 text-xs font-semibold hover:bg-muted/50 rounded-lg transition-colors"
+                        className="sm:hidden px-3 py-1.5 text-xs font-semibold hover:bg-muted/50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                         aria-label={t('common.clear', 'Clear')}
                     >
                         {t('common.clear', 'Clear')}
@@ -23,14 +23,14 @@ export const BulkActionsBar = ({ selectedCameraIds, setSelectedCameraIds, handle
                 <div className="flex items-center justify-center gap-2 w-full sm:w-auto">
                     <button
                         onClick={() => setSelectedCameraIds([])}
-                        className="hidden sm:block px-3 py-1.5 text-xs font-semibold hover:bg-muted/50 rounded-lg transition-colors"
+                        className="hidden sm:block px-3 py-1.5 text-xs font-semibold hover:bg-muted/50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                         aria-label={t('common.clear', 'Clear')}
                     >
                         {t('common.clear', 'Clear')}
                     </button>
                     <button
                         onClick={handleBulkExport}
-                        className="flex-1 sm:flex-none px-3 sm:px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-xs font-bold rounded-lg transition-all flex items-center justify-center shadow-lg shadow-green-500/20 active:scale-95 whitespace-nowrap"
+                        className="flex-1 sm:flex-none px-3 sm:px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-xs font-bold rounded-lg transition-all flex items-center justify-center shadow-lg shadow-green-500/20 active:scale-95 whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                         aria-label={t('cameras.export_selected', 'Export Selected')}
                         title={t('cameras.export_selected', 'Export Selected')}
                     >
@@ -40,7 +40,7 @@ export const BulkActionsBar = ({ selectedCameraIds, setSelectedCameraIds, handle
                     </button>
                     <button
                         onClick={handleBulkDelete}
-                        className="flex-1 sm:flex-none px-3 sm:px-4 py-2 bg-red-500 hover:bg-red-600 text-white text-xs font-bold rounded-lg transition-all flex items-center justify-center shadow-lg shadow-red-500/20 active:scale-95 whitespace-nowrap"
+                        className="flex-1 sm:flex-none px-3 sm:px-4 py-2 bg-red-500 hover:bg-red-600 text-white text-xs font-bold rounded-lg transition-all flex items-center justify-center shadow-lg shadow-red-500/20 active:scale-95 whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                         aria-label={t('cameras.delete_selected', 'Delete Selected')}
                         title={t('cameras.delete_selected', 'Delete Selected')}
                     >

--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -88,7 +88,7 @@ export const Layout = ({ children, activeTab, onTabChange, theme, toggleTheme })
                 <div className="lg:hidden sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border p-3 flex items-center justify-between w-full max-w-full overflow-hidden">
                     <button
                         onClick={() => setSidebarOpen(true)}
-                        className="p-2 rounded-lg hover:bg-accent shrink-0"
+                        className="p-2 rounded-lg hover:bg-accent shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                         aria-label={t('layout.open_sidebar', 'Open Sidebar')}
                     >
                         <Menu className="w-6 h-6" />


### PR DESCRIPTION
💡 What: Added standard `focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card` styles to the "Open Sidebar" mobile toggle button in `Layout.jsx` and the action buttons in `BulkActionsBar.jsx`.

🎯 Why: These buttons lacked visual feedback when navigated to via keyboard (e.g., using the Tab key), which hinders usability for power users and those relying on assistive technologies.

📸 Before/After: Before, tabbing to these buttons showed no visual outline. After, they consistently display a primary-colored ring identical to the rest of the application's interactive elements.

♿ Accessibility: Ensures WCAG compliance for focus visibility, allowing keyboard-only users to clearly identify the currently active interactive element.

---
*PR created automatically by Jules for task [10143995911174842914](https://jules.google.com/task/10143995911174842914) started by @spupuz*