### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in webhook validation

### DIFF
--- a/.github/scripts/test_settings_service.py
+++ b/.github/scripts/test_settings_service.py
@@ -45,7 +45,7 @@ def test_validate_setting_valid():
     validate_setting("mqtt_port", "65535")
 
     # notify_webhook_url
-    validate_setting("notify_webhook_url", "http://localhost:8080/webhook")
+    validate_setting("notify_webhook_url", "http://192.168.1.100/webhook")
     validate_setting("notify_webhook_url", "https://example.com/api")
     validate_setting("notify_webhook_url", "")  # empty value is allowed for clearing
 
@@ -122,7 +122,15 @@ def test_validate_webhook_url_valid_ip():
     # Should not raise any exception
     _validate_webhook_url("http://192.168.1.100")
     _validate_webhook_url("https://8.8.8.8:8080/webhook")
-    _validate_webhook_url("http://127.0.0.1")
+
+def test_validate_webhook_url_blocked_ips():
+    """Test that link-local, loopback, and unspecified IPs are blocked."""
+    with pytest.raises(ValueError, match="Unsafe Webhook URL"):
+        _validate_webhook_url("http://169.254.169.254")
+    with pytest.raises(ValueError, match="Unsafe Webhook URL"):
+        _validate_webhook_url("http://127.0.0.1")
+    with pytest.raises(ValueError, match="Unsafe Webhook URL"):
+        _validate_webhook_url("http://0.0.0.0")
 
 def test_validate_webhook_url_invalid_format():
     """Test invalid URL format."""

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - Webhook Validation SSRF Protection
+**Vulnerability:** The webhook URL validation logic explicitly blocked link-local and multicast IPs but failed to block loopback (`127.0.0.1`) and unspecified (`0.0.0.0`) addresses.
+**Learning:** This omission allowed potential SSRF attacks targeting internal services running on the loopback interface, bypassing external network controls.
+**Prevention:** Ensure all non-routable, non-private internal address ranges (loopback, unspecified, link-local, multicast) are explicitly blocked when validating external URLs provided by users.

--- a/backend/settings_service.py
+++ b/backend/settings_service.py
@@ -29,8 +29,8 @@ def _validate_webhook_url(value: str):
                 ip_addr = ipaddress.ip_address(socket.gethostbyname(host))
             except Exception:
                 return
-        if ip_addr.is_loopback or ip_addr.is_private or ip_addr.is_reserved or ip_addr.is_link_local:
-            pass
+        if ip_addr.is_loopback or ip_addr.is_unspecified or ip_addr.is_link_local or ip_addr.is_multicast:
+            raise ValueError('Unsafe Webhook URL')
     except Exception as e:
         if isinstance(e, ValueError): raise e
         raise ValueError(f'Invalid or unreachable URL: {str(e)}')

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -21,7 +21,7 @@ def is_safe_webhook_url(url: str) -> bool:
         # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
         # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
         # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
-        if ip_obj.is_link_local or ip_obj.is_multicast:
+        if ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_loopback or ip_obj.is_unspecified:
             return False
 
         return True


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Webhook validation previously only blocked link-local and multicast addresses, failing to block loopback (`127.0.0.1`) and unspecified (`0.0.0.0`) IP addresses. This allowed SSRF (Server-Side Request Forgery) attacks against internal services listening on these local interfaces.
🎯 **Impact:** An attacker could craft a webhook payload with a loopback IP to target sensitive services running locally, bypassing external network firewalls.
🔧 **Fix:** Added `is_loopback` and `is_unspecified` IP blocks to both `backend/utils.py` (`is_safe_webhook_url`) and `backend/settings_service.py` (`_validate_webhook_url`). Updated unit tests to enforce the blocklist. Private IPs (like `192.168.x.x`) remain permitted for necessary local network webhooks like Home Assistant integrations.
✅ **Verification:** Verified via `PYTHONPATH=backend python -m pytest .github/scripts/test_settings_service.py` that the new constraints appropriately throw a `ValueError` with `Unsafe Webhook URL`.

---
*PR created automatically by Jules for task [12932121643829054712](https://jules.google.com/task/12932121643829054712) started by @spupuz*