### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF Bypass via Redirects in Notifications

### DIFF
--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -100,7 +100,7 @@ def _send_telegram_notification(
                     with open(image_path, 'rb') as f:
                         files = {'photo': f}
                         data = {'chat_id': tg_chat, 'caption': caption, 'parse_mode': 'HTML'}
-                        resp = requests.post(url, data=data, files=files, proxies=proxies, timeout=10)
+                        resp = requests.post(url, data=data, files=files, proxies=proxies, timeout=10, allow_redirects=False)
                         resp.raise_for_status()
                 else:
                     # Send Text
@@ -109,7 +109,7 @@ def _send_telegram_notification(
                         "chat_id": tg_chat,
                         "text": caption,
                         "parse_mode": "HTML"
-                    }, proxies=proxies, timeout=5)
+                    }, proxies=proxies, timeout=5, allow_redirects=False)
                     resp.raise_for_status()
 
                 # If we succeed, break the retry loop

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -843,7 +843,7 @@ def test_notification(config: schemas.TestNotificationConfig, db: Session = Depe
             import time
             for attempt in range(max(1, retries)):
                 try:
-                    resp = requests.post(api_url, json=payload, proxies=proxies, timeout=10)
+                    resp = requests.post(api_url, json=payload, proxies=proxies, timeout=10, allow_redirects=False)
                     if not resp.ok:
                         raise ValueError(f"Telegram API Error: {resp.text}")
                     return {"status": "success", "message": "Test Telegram message sent"}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) bypass. While webhook URLs were validated using `utils.is_safe_webhook_url` to prevent direct requests to link-local/multicast IPs, `requests.post` and `requests.get` by default follow HTTP 302 redirects. An attacker could supply a safe external URL that responds with a redirect to a malicious internal IP (e.g., `169.254.169.254`), bypassing the initial URL validation.
🎯 **Impact:** An attacker could exploit this to perform port scanning, interact with internal services, or retrieve sensitive cloud metadata.
🔧 **Fix:** Added `allow_redirects=False` to the `requests.post` calls in `backend/routers/events.py` (Telegram notifications) and `backend/routers/settings.py` (Telegram test notifications) to ensure the request library does not automatically follow redirects.
✅ **Verification:** Verified by checking that `allow_redirects=False` is present in the affected files. Also ran backend tests (`.github/scripts/test_settings_service.py` and `scripts/test_schemas.py`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [574837678239077651](https://jules.google.com/task/574837678239077651) started by @spupuz*