### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF vulnerability via loopback IPs

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -19,9 +19,10 @@ def is_safe_webhook_url(url: str) -> bool:
         ip_obj = ipaddress.ip_address(ip)
 
         # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
+        # Also block loopback (127.x.x.x) and unspecified (0.0.0.0) to prevent internal service abuse.
         # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
         # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
-        if ip_obj.is_link_local or ip_obj.is_multicast:
+        if ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_loopback or ip_obj.is_unspecified:
             return False
 
         return True


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) allowed attackers to target internal services via loopback (`127.0.0.1`) or unspecified (`0.0.0.0`) IP addresses, as they were not explicitly blocked in the `is_safe_webhook_url` validation logic.
🎯 Impact: Attackers could abuse webhooks to interact with internal services on the NVR host machine, potentially bypassing external security controls.
🔧 Fix: Updated `backend/utils.py` to explicitly block `is_loopback` and `is_unspecified` IP addresses alongside the existing link-local and multicast checks.
✅ Verification: Ran unit tests verifying `is_safe_webhook_url` blocks loopback and unspecified IP addresses (`pytest .github/scripts/`). Checked linter with `ruff check backend/utils.py`.

---
*PR created automatically by Jules for task [5478015787257323377](https://jules.google.com/task/5478015787257323377) started by @spupuz*