### PR TITLE
⚡ Bolt: Optimize background camera fetch to reduce DB load

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -15,6 +15,10 @@ def get_cameras(db: Session, skip: int = 0, limit: int = 100):
         selectinload(models.Camera.storage_profile)
     ).order_by(models.Camera.sort_order.asc(), models.Camera.id.asc()).offset(skip).limit(limit).all()
 
+def get_active_cameras_lightweight(db: Session):
+    # ⚡ Bolt: Provide a lightweight O(1) query without eager loading overhead for background periodic tasks
+    return db.query(models.Camera).filter(models.Camera.is_active == True).all()  # noqa: E712
+
 def get_camera_by_rtsp_url(db: Session, rtsp_url: str):
     return db.query(models.Camera).filter(models.Camera.rtsp_url == rtsp_url).first()
 

--- a/backend/health_service.py
+++ b/backend/health_service.py
@@ -140,7 +140,8 @@ async def check_camera_health():
                 with database.get_db_ctx() as db:
                     # Process each camera reported by engine
                     # Note: We only care about cameras that are supposed to be active
-                    cameras = crud.get_cameras(db)
+                    # ⚡ Bolt: Use lightweight query to avoid relationship eager loading overhead
+                    cameras = crud.get_active_cameras_lightweight(db)
 
                     for camera in cameras:
                         await _fetch_and_update_health(db, engine_status, camera=camera)


### PR DESCRIPTION
💡 What: Refactored the database query in `health_service.py` to bypass `crud.get_cameras(db)` (which eagerly loads multiple entity relationships) and instead use a lightweight `crud.get_active_cameras_lightweight(db)` query.

🎯 Why: During background periodic loops like checking camera health, loading relations like `storage_profile` and `groups` for all active cameras unnecessarily bloats memory because these relationships are not used by the health check function. Removing the eager loader significantly speeds up the query. Also added a `is_active == True` filter directly at the database level rather than filtering post-fetch, ensuring memory footprint is minimized. 

📊 Impact: Reduces memory load and speeds up the periodic DB query check for the `health_service.py` daemon by preventing overhead associated with `selectinload` queries inside the underlying `get_cameras()` call. DB will fetch records faster without executing the extra queries to resolve relationships.

🔬 Measurement: Verify with `PYTHONPATH=backend python3 -m pytest .github/scripts/test_health_service.py` to ensure behavior consistency, and note query times on production when processing large quantities of cameras.

---
*PR created automatically by Jules for task [14404129939237055577](https://jules.google.com/task/14404129939237055577) started by @spupuz*