### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability allowing loopback addresses

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -21,7 +21,7 @@ def is_safe_webhook_url(url: str) -> bool:
         # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
         # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
         # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
-        if ip_obj.is_link_local or ip_obj.is_multicast:
+        if ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_loopback or ip_obj.is_unspecified:
             return False
 
         return True


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) bypass due to missing validation for loopback (`127.0.0.0/8`, `::1`) and unspecified (`0.0.0.0`, `::`) IP addresses in user-provided webhook URLs. The existing checks only blocked link-local and multicast addresses.
🎯 Impact: An attacker could configure a webhook URL pointing to `http://127.0.0.1:<internal_port>` or `http://0.0.0.0:<internal_port>` to bypass external firewalls, interact with internal APIs, or access cloud metadata services running on the host machine itself.
🔧 Fix: Updated `is_safe_webhook_url` in `backend/utils.py` to explicitly check `ip_obj.is_loopback` and `ip_obj.is_unspecified` before allowing the webhook request.
✅ Verification: Validated the fix by running the full backend test suite (`pytest .github/scripts/`) and ensuring no functional regressions occurred. The linting rules (`ruff check`) were also satisfied.

---
*PR created automatically by Jules for task [2387432602453314780](https://jules.google.com/task/2387432602453314780) started by @spupuz*