### PR TITLE
⚡ Bolt: Prevent memory bloat in health service background task

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -15,6 +15,9 @@ def get_cameras(db: Session, skip: int = 0, limit: int = 100):
         selectinload(models.Camera.storage_profile)
     ).order_by(models.Camera.sort_order.asc(), models.Camera.id.asc()).offset(skip).limit(limit).all()
 
+def get_active_cameras_lightweight(db: Session):
+    return db.query(models.Camera).filter(models.Camera.is_active == True).all()  # noqa: E712
+
 def get_camera_by_rtsp_url(db: Session, rtsp_url: str):
     return db.query(models.Camera).filter(models.Camera.rtsp_url == rtsp_url).first()
 

--- a/backend/health_service.py
+++ b/backend/health_service.py
@@ -140,7 +140,7 @@ async def check_camera_health():
                 with database.get_db_ctx() as db:
                     # Process each camera reported by engine
                     # Note: We only care about cameras that are supposed to be active
-                    cameras = crud.get_cameras(db)
+                    cameras = crud.get_active_cameras_lightweight(db)
 
                     for camera in cameras:
                         await _fetch_and_update_health(db, engine_status, camera=camera)


### PR DESCRIPTION
💡 What: Replaced the eager-loaded `crud.get_cameras` with a tailored `crud.get_active_cameras_lightweight` in the background health check task.
🎯 Why: The health check task runs in an infinite loop every 10 seconds. The previous `get_cameras` method used `selectinload` to eager-load `groups` and `storage_profile` for every camera, which causes unnecessary memory bloat and database overhead for a background process that only needs to read `camera.id`, `camera.name`, and update `camera.status`.
📊 Impact: Reduces memory allocation and eliminates 2 redundant O(1) batched JOIN queries per loop iteration across all active cameras.
🔬 Measurement: Verify by running tests via `PYTHONPATH=backend python3 -m pytest .github/scripts/test_health_service.py` and checking memory usage of the backend process during operation.

---
*PR created automatically by Jules for task [16782196355062066229](https://jules.google.com/task/16782196355062066229) started by @spupuz*