### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability allowing local network access

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -21,7 +21,7 @@ def is_safe_webhook_url(url: str) -> bool:
         # Block link-local (169.254.x.x) and multicast to prevent SSRF against cloud metadata and sensitive internal addresses.
         # Note: We intentionally allow private IPs (like 192.168.x.x) because users of this NVR system
         # rely on webhooks to trigger local home automation services (e.g. Home Assistant).
-        if ip_obj.is_link_local or ip_obj.is_multicast:
+        if ip_obj.is_link_local or ip_obj.is_multicast or ip_obj.is_loopback or ip_obj.is_unspecified:
             return False
 
         return True


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `is_safe_webhook_url` function failed to block loopback (e.g., `127.0.0.1`, `::1`) and unspecified IP addresses (`0.0.0.0`), allowing a potential Server-Side Request Forgery (SSRF) attack.
🎯 **Impact:** An attacker could exploit the webhook feature to make unauthorized internal network requests to local unauthenticated services, potentially bypassing network firewalls.
🔧 **Fix:** Modified the validation logic in `backend/utils.py` to explicitly reject URLs that resolve to IPs where `is_loopback` or `is_unspecified` are true.
✅ **Verification:** Verified that loopback and unspecified addresses are correctly blocked while private local networks remain accessible (as required for Home Assistant webhooks). Passed backend tests.

---
*PR created automatically by Jules for task [15547872381742993045](https://jules.google.com/task/15547872381742993045) started by @spupuz*