### PR TITLE
🎨 Palette: Add keyboard focus indicators to Logs action buttons

### DIFF
--- a/frontend/src/pages/Logs.jsx
+++ b/frontend/src/pages/Logs.jsx
@@ -127,7 +127,7 @@ export const Logs = () => {
                 </div>
                 <button
                     onClick={handleDownload}
-                    className="flex items-center space-x-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 transition-all shadow-sm"
+                    className="flex items-center space-x-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 transition-all shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
                     <Download className="w-4 h-4" />
                     <span>{t('logs.download_report', 'Download Report')}</span>
@@ -176,7 +176,7 @@ export const Logs = () => {
                 <div className="flex items-center gap-2 ml-auto">
                     <button
                         onClick={() => setAutoScroll(!autoScroll)}
-                        className={`p-2 rounded-md border transition-colors ${autoScroll ? 'bg-primary/10 border-primary/20 text-primary' : 'bg-background border-border text-muted-foreground'}`}
+                        className={`p-2 rounded-md border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${autoScroll ? 'bg-primary/10 border-primary/20 text-primary' : 'bg-background border-border text-muted-foreground'}`}
                         title={autoScroll ? t('logs.pause_scroll', 'Pause Auto-scroll') : t('logs.resume_scroll', 'Resume Auto-scroll')}
                         aria-label={autoScroll ? t('logs.pause_scroll', 'Pause Auto-scroll') : t('logs.resume_scroll', 'Resume Auto-scroll')}
                     >
@@ -184,7 +184,7 @@ export const Logs = () => {
                     </button>
                     <button
                         onClick={fetchLogs}
-                        className="p-2 rounded-md hover:bg-accent text-muted-foreground"
+                        className="p-2 rounded-md hover:bg-accent text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                         title={t('logs.refresh_now', 'Refresh Now')}
                         aria-label={t('logs.refresh_now', 'Refresh Now')}
                     >
@@ -192,7 +192,7 @@ export const Logs = () => {
                     </button>
                     <button
                         onClick={() => setShowSettings(true)}
-                        className="p-2 rounded-md hover:bg-accent text-muted-foreground"
+                        className="p-2 rounded-md hover:bg-accent text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                         title={t('logs.log_rotation_settings', 'Log Rotation Settings')}
                         aria-label={t('logs.log_rotation_settings', 'Log Rotation Settings')}
                     >


### PR DESCRIPTION
💡 What: Added `focus-visible:ring-2`, `focus-visible:ring-primary`, and offset styles to the interactive action buttons in the `Logs.jsx` component (Download, Auto-scroll, Refresh, Settings).
🎯 Why: These critical action buttons lacked visual indicators for keyboard navigation, making it difficult for keyboard-only users to know which element they were currently interacting with.
📸 Before/After: Before, pressing Tab wouldn't show a ring on the buttons. After, pressing Tab prominently outlines the focused button with the primary theme color.
♿ Accessibility: Improved keyboard accessibility (WCAG 2.4.7 Focus Visible) by ensuring all interactive icon-only buttons on the Logs page have distinct focus indicators.

---
*PR created automatically by Jules for task [16962457021722659535](https://jules.google.com/task/16962457021722659535) started by @spupuz*