### PR TITLE
⚡ Bolt: Push event camera access filtering to DB layer to prevent memory bloat

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-07-31 - Background Task Query Optimization
 **Learning:** Reusing API-oriented CRUD functions (like `crud.get_cameras`) that eagerly load relationships (`selectinload`) in tight background loops (like `health_service`) causes unnecessary memory bloat and database load.
 **Action:** Create lightweight queries (e.g., `crud.get_active_cameras_lightweight`) tailored to fetch only the required models for performance-sensitive background tasks.
+
+## 2024-08-25 - Pagination and Authorization Filtering
+**Learning:** In paginated endpoints (like fetching events with a `limit`), performing role-based authorization filtering (e.g., checking `allowed_ids`) in memory via a Python list comprehension *after* the DB fetch causes severe issues: it loads potentially thousands of useless records into memory (O(N) memory bloat), and more importantly, it causes implicit data truncation (returning fewer than `limit` events even if more authorized events exist in the database).
+**Action:** Always pass authorized entity IDs (like `allowed_camera_ids`) down to the DB query layer (CRUD function) to filter natively via `.in_()` before `.limit()` is applied.

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -139,10 +139,16 @@ def get_events(
     camera_id: int = None,
     type: str = None,
     date: str = None,
+    allowed_camera_ids: list[int] = None,
 ):
     query = db.query(models.Event)
     if camera_id:
         query = query.filter(models.Event.camera_id == camera_id)
+    elif allowed_camera_ids is not None:
+        # ⚡ Bolt: Optimize by filtering authorized cameras natively in DB instead of Python
+        # to eliminate memory bloat and fix implicit pagination truncation.
+        query = query.filter(models.Event.camera_id.in_(allowed_camera_ids))
+
     if type:
         query = query.filter(models.Event.type == type)
     if date:

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -576,10 +576,8 @@ def read_events(
     ),
 ):
     user, is_token = auth_info
-    events = crud.get_events(
-        db, skip=skip, limit=limit, camera_id=camera_id, type=type, date=date
-    )
 
+    allowed_ids = None
     if user.role == "viewer" and user.restrict_camera_access:
         allowed_ids = crud.get_allowed_camera_ids_for_user(
             db, user.id, permission="replay"
@@ -590,7 +588,12 @@ def read_events(
                     status_code=403,
                     detail="Not authorized to replay events for this camera",
                 )
-            events = [e for e in events if e.camera_id in allowed_ids]
+
+    # ⚡ Bolt: Pass allowed_ids down to crud layer to filter natively in DB query.
+    # This prevents O(N) memory allocation and filtering on massive datasets.
+    events = crud.get_events(
+        db, skip=skip, limit=limit, camera_id=camera_id, type=type, date=date, allowed_camera_ids=allowed_ids
+    )
 
     return events
 


### PR DESCRIPTION
💡 What: Moved the camera authorization filtering in the events endpoint from a Python list comprehension to the native database query using `.in_()`.

🎯 Why: Previously, the events endpoint fetched a large block of events into memory and then filtered out unauthorized cameras in Python. This caused O(N) memory allocation on massive datasets and created an implicit pagination truncation bug (where a request for `limit=100` might only return 50 items if the other 50 belonged to unauthorized cameras).

📊 Impact: Significantly reduces backend memory bloat when restricted viewers request events. Eliminates the data truncation bug, ensuring accurate paginated results. Query execution is now O(1) in the database rather than O(N) memory allocations in Python.

🔬 Measurement: 
- Verify via the test suite (`PYTHONPATH=backend python3 -m pytest .github/scripts/test_crud.py`)
- Run a manual script creating 100,000 events and querying as a restricted user to observe the performance difference and correct pagination length.

---
*PR created automatically by Jules for task [13964608983526702250](https://jules.google.com/task/13964608983526702250) started by @spupuz*