### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via HTTP redirect bypass in requests

### DIFF
--- a/.github/scripts/test_telemetry_service.py
+++ b/.github/scripts/test_telemetry_service.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Add backend directory to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../backend')))
+
+import telemetry_service
+
+@patch('telemetry_service.requests.get')
+@patch('telemetry_service.get_system_info')
+@patch('telemetry_service.get_app_version')
+@patch('telemetry_service.gather_metrics')
+@patch('telemetry_service.database.get_db_ctx')
+def test_send_telemetry_ssrf_protection(mock_get_db_ctx, mock_gather, mock_version, mock_sysinfo, mock_get):
+    # Setup mocks
+    mock_db = MagicMock()
+    mock_get_db_ctx.return_value.__enter__.return_value = mock_db
+
+    # Mock settings to enable telemetry
+    mock_enabled_setting = MagicMock()
+    mock_enabled_setting.value = "true"
+
+    mock_instance_id_setting = MagicMock()
+    mock_instance_id_setting.value = "test-instance-id"
+
+    # Configure mock query chain
+    mock_query = MagicMock()
+    mock_db.query.return_value = mock_query
+    mock_filter = MagicMock()
+    mock_query.filter_by.return_value = mock_filter
+    mock_filter.first.side_effect = [mock_enabled_setting, mock_instance_id_setting]
+
+    mock_gather.return_value = {
+        "cameras": 0, "users": 0, "groups": 0, "events": 0, "notifications": False,
+        "mqtt_active": False, "motion_opencv": 0, "motion_onvif": 0, "motion_ai_engine": 0, "motion_ai": 0,
+        "onvif_count": 0, "substream_count": 0
+    }
+    mock_sysinfo.return_value = {
+        "os": "test", "arch": "test", "cpu_count": 1, "processor": "test", "ram_gb": 1, "gpu_active": False
+    }
+    mock_version.return_value = "1.0.0"
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+
+    # Run the function
+    telemetry_service.send_telemetry()
+
+    # Verify allow_redirects=False is passed to requests.get
+    mock_get.assert_called_once()
+    kwargs = mock_get.call_args[1]
+    assert kwargs.get('allow_redirects') is False, "allow_redirects=False must be explicitly set for SSRF protection"

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** The webhook URL validation logic explicitly blocked link-local and multicast IPs but failed to block loopback (`127.0.0.1`) and unspecified (`0.0.0.0`) addresses.
 **Learning:** This omission allowed potential SSRF attacks targeting internal services running on the loopback interface, bypassing external network controls.
 **Prevention:** Ensure all non-routable, non-private internal address ranges (loopback, unspecified, link-local, multicast) are explicitly blocked when validating external URLs provided by users.
+## 2024-05-24 - Missing SSRF protection in Telemetry requests
+**Vulnerability:** The telemetry service in the backend uses `requests.get` to send data to a user-configurable URL (`CLOUDFLARE_TELEMETRY_URL` from env variables) but fails to explicitly disable HTTP redirects (`allow_redirects=False`).
+**Learning:** `requests.get` follows HTTP redirects by default, which can be exploited by an attacker to bypass basic SSRF checks (like checking the initial URL) by having the external server redirect the request to internal addresses (e.g. `127.0.0.1` or `169.254.169.254`).
+**Prevention:** Always set `allow_redirects=False` on `requests.get` and `requests.post` calls to external or user-configurable URLs, regardless of if they are parsed or validated beforehand.

--- a/backend/telemetry_service.py
+++ b/backend/telemetry_service.py
@@ -186,7 +186,7 @@ def send_telemetry():
             
             # --- Primary: Cloudflare Analytics Worker ---
             try:
-                cf_response = requests.get(cf_telemetry_url, params=payload, headers=headers, timeout=10)
+                cf_response = requests.get(cf_telemetry_url, params=payload, headers=headers, timeout=10, allow_redirects=False)
                 if cf_response.ok:
                     logger.info(f"Telemetry sent to Cloudflare Worker (Status: {cf_response.status_code})")
                 else:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `requests.get` call in `backend/telemetry_service.py` to `CLOUDFLARE_TELEMETRY_URL` failed to restrict HTTP redirects, which could allow an attacker to bypass SSRF validation (if any) and probe internal networks via 301/302 redirects.
🎯 Impact: Attackers who can control environment variables to supply a malicious external URL can trick the application into making internal HTTP requests, scanning for exposed services.
🔧 Fix: Explicitly added `allow_redirects=False` to the vulnerable `requests.get` call in `backend/telemetry_service.py`.
✅ Verification: Added a test file `.github/scripts/test_telemetry_service.py` that validates the `allow_redirects=False` argument is passed correctly. Running `PYTHONPATH=backend python3 -m pytest .github/scripts/test_telemetry_service.py` passes successfully.

---
*PR created automatically by Jules for task [4872816990087733246](https://jules.google.com/task/4872816990087733246) started by @spupuz*