### PR TITLE
🎨 Palette: Add keyboard focus states to 2FA login buttons

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -307,14 +307,14 @@ export const Login = () => {
                                         setRecoveryCode('');
                                         setError('');
                                     }}
-                                    className="w-full text-sm text-primary hover:text-primary/80 transition-colors"
+                                    className="w-full text-sm text-primary hover:text-primary/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
                                 >
                                     {useRecoveryCode ? "Use Authenticator App Instead" : "Lost device? Use Recovery Code"}
                                 </button>
                                 <button
                                     type="button"
                                     onClick={() => { setRequire2FA(false); setTotpCode(''); setRecoveryCode(''); setError(''); setUseRecoveryCode(false); }}
-                                    className="w-full text-sm text-muted-foreground hover:text-primary transition-colors"
+                                    className="w-full text-sm text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
                                 >
                                     Back to Login
                                 </button>


### PR DESCRIPTION
💡 What: Added `focus-visible` utility classes to the 2FA recovery code toggle and the "Back to Login" buttons.
🎯 Why: To improve keyboard navigation accessibility by providing a clear visual indicator when these interactive elements receive focus via the keyboard.
📸 Before/After: N/A (CSS states)
♿ Accessibility: Ensures WCAG compliance for focus visibility on custom text buttons that previously lacked active focus outlines.

---
*PR created automatically by Jules for task [12202141997447545684](https://jules.google.com/task/12202141997447545684) started by @spupuz*