### PR TITLE
🎨 Palette: Add proper keyboard focus and ARIA roles to camera edit modal

### DIFF
--- a/frontend/src/components/Cameras/AddEditModal/CameraAddEditModal.jsx
+++ b/frontend/src/components/Cameras/AddEditModal/CameraAddEditModal.jsx
@@ -128,7 +128,7 @@ export const CameraAddEditModal = ({
                         </div>
                         <button
                             onClick={() => { setShowAddModal(false); setEditingId(null); setCloneSourceId(''); }}
-                            className="p-2 hover:bg-muted rounded-full transition-colors"
+                            className="p-2 hover:bg-muted rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                             aria-label={t('common.close', 'Close')}
                         >
                             <X className="w-5 h-5" />
@@ -162,8 +162,8 @@ export const CameraAddEditModal = ({
                                     <div className="flex justify-between items-center mb-2">
                                         <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider text-primary/70">{t('cameras.categories_to_import', 'Categories to Import')}</span>
                                         <div className="flex gap-2">
-                                            <button type="button" className="text-[10px] uppercase font-bold text-blue-600 hover:underline" onClick={() => { setSelectedCloneCategories(CAMERA_SETTINGS_CATEGORIES.map(c => c.id)); performClone(cloneSourceId, CAMERA_SETTINGS_CATEGORIES.map(c => c.id)); }}>{t('cameras.all', 'All')}</button>
-                                            <button type="button" className="text-[10px] uppercase font-bold text-muted-foreground hover:underline" onClick={() => { setSelectedCloneCategories([]); performClone(cloneSourceId, []); }}>{t('cameras.none', 'None')}</button>
+                                            <button type="button" className="text-[10px] uppercase font-bold text-blue-600 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm" onClick={() => { setSelectedCloneCategories(CAMERA_SETTINGS_CATEGORIES.map(c => c.id)); performClone(cloneSourceId, CAMERA_SETTINGS_CATEGORIES.map(c => c.id)); }}>{t('cameras.all', 'All')}</button>
+                                            <button type="button" className="text-[10px] uppercase font-bold text-muted-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm" onClick={() => { setSelectedCloneCategories([]); performClone(cloneSourceId, []); }}>{t('cameras.none', 'None')}</button>
                                         </div>
                                     </div>
                                     <div className="grid grid-cols-2 gap-2 bg-background/50 p-2 rounded-lg border border-primary/10">
@@ -186,11 +186,17 @@ export const CameraAddEditModal = ({
                         </div>
                     )}
 
-                    <div className="flex space-x-4 mb-4 border-b border-border text-[11px] overflow-x-auto flex-nowrap min-h-[40px] pb-1 scrollbar-hide scroll-smooth relative">
+                    <div
+                        role="tablist"
+                        aria-label={t('cameras.settings_categories', 'Settings Categories')}
+                        className="flex space-x-4 mb-4 border-b border-border text-[11px] overflow-x-auto flex-nowrap min-h-[40px] pb-1 scrollbar-hide scroll-smooth relative"
+                    >
                         {tabs.map((tab) => (
                             <button
                                 key={tab.id}
-                                className={`pb-2 flex items-center gap-1.5 flex-shrink-0 transition-all ${activeTab === tab.id ? 'border-b-2 border-primary font-bold text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+                                role="tab"
+                                aria-selected={activeTab === tab.id}
+                                className={`pb-2 flex items-center gap-1.5 flex-shrink-0 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-t-sm ${activeTab === tab.id ? 'border-b-2 border-primary font-bold text-primary' : 'text-muted-foreground hover:text-foreground'}`}
                                 onClick={() => setActiveTab(tab.id)}
                             >
                                 <tab.icon className="w-3.5 h-3.5" />


### PR DESCRIPTION
💡 What: Added `role="tablist"` and `role="tab"` to the settings categories tabs in `CameraAddEditModal.jsx`, along with `aria-selected` attributes. Also added `focus-visible` CSS rings to the tabs, the close modal button, and the "All"/"None" category cloning buttons.
🎯 Why: To ensure keyboard users can effectively navigate and perceive their focus state within the modal, and to allow screen readers to correctly interpret the settings categories as a tabbed interface.
📸 Before/After: N/A (CSS focus state and accessibility tree changes)
♿ Accessibility: Improves WCAG compliance for keyboard navigation and screen reader semantics.

---
*PR created automatically by Jules for task [14866313168164768151](https://jules.google.com/task/14866313168164768151) started by @spupuz*