### PR TITLE
⚡ Bolt: [performance improvement] Memoize SortableVideoPlayerWrapper

### DIFF
--- a/frontend/src/components/Cameras/SortableVideoPlayerWrapper.jsx
+++ b/frontend/src/components/Cameras/SortableVideoPlayerWrapper.jsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripHorizontal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-export function SortableVideoPlayerWrapper(props) {
+// ⚡ Bolt Optimization:
+// Wrapped in React.memo to ensure the Sortable wrapper
+// also avoids redundant renders when unrelated items in the grid are reordered.
+// Impact: Prevents O(n) component updates when a single item is dragged.
+export const SortableVideoPlayerWrapper = memo(function SortableVideoPlayerWrapper(props) {
     const { t } = useTranslation();
     const {
         attributes,
@@ -40,4 +44,4 @@ export function SortableVideoPlayerWrapper(props) {
             {props.children}
         </div>
     );
-}
+});


### PR DESCRIPTION
💡 What: Wrap `SortableVideoPlayerWrapper` with `React.memo` to prevent redundant component updates.

🎯 Why: Dragging a camera card inside the `LiveView` grid updates the parent context state, which triggers a re-render. Since `VideoPlayer` contains a lot of logic and elements, re-rendering all of them during a drag severely reduces performance.

📊 Impact: Wrapping `SortableVideoPlayerWrapper` with `React.memo` prevents O(n) re-renders when a single camera is dragged and reordered in the Live View grid.

🔬 Measurement: Check React Developer Tools profiler when dragging/reordering cameras; the un-dragged cameras should not re-render.

---
*PR created automatically by Jules for task [13714592919088802](https://jules.google.com/task/13714592919088802) started by @spupuz*