### PR TITLE
⚡ Bolt: Eliminate N+1 queries in bulk settings save

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -95,6 +95,8 @@ def update_bulk_settings(settings: dict, db: Session = Depends(database.get_db),
         new_val = str(settings["go2rtc_enabled"]).lower() == "true"
         go2rtc_changed = old_val != new_val
 
+    # ⚡ Bolt: Prepare settings and update in bulk to prevent N+1 DB operations
+    processed_settings = {}
     for key, value in settings.items():
         # Validation for known numeric keys
         numeric_keys = [
@@ -118,7 +120,9 @@ def update_bulk_settings(settings: dict, db: Session = Depends(database.get_db),
         if key in boolean_keys:
             value = str(value).lower()
         
-        set_setting(db, key, str(value))
+        processed_settings[key] = str(value)
+
+    settings_service.set_bulk_settings(db, processed_settings)
     
     # A go2rtc toggle changes every camera's effective URL → full restart + re-sync.
     if go2rtc_changed:

--- a/backend/settings_service.py
+++ b/backend/settings_service.py
@@ -78,6 +78,24 @@ def validate_setting(key: str, value: str):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid value for {key}: {str(e)}")
 
+def set_bulk_settings(db: Session, settings: dict):
+    """Set multiple settings at once, resolving N+1 DB operations."""
+    for key, value in settings.items():
+        validate_setting(key, value)
+
+    keys = list(settings.keys())
+    existing = db.query(models.SystemSettings).filter(models.SystemSettings.key.in_(keys)).all()
+    existing_map = {s.key: s for s in existing}
+
+    for key, value in settings.items():
+        if key in existing_map:
+            existing_map[key].value = value
+        else:
+            db.add(models.SystemSettings(key=key, value=value))
+
+    db.commit()
+
+
 def set_setting(db: Session, key: str, value: str, description: str = None):
     """Set a setting value, create if doesn't exist"""
     validate_setting(key, value)


### PR DESCRIPTION
💡 What: Introduced a set_bulk_settings method to batch validate, fetch, and save all settings in a single transaction.
🎯 Why: The previous implementation caused N+1 database queries, querying and committing each setting sequentially during a bulk update.
📊 Impact: Reduces O(N) queries (select + commit per setting) to O(1) during bulk settings saves.
🔬 Measurement: Check the number of SQL queries generated when submitting the settings form, ensuring it is a single bulk operation.

---
*PR created automatically by Jules for task [4992799493661820195](https://jules.google.com/task/4992799493661820195) started by @spupuz*