### PR TITLE
🎨 Palette: Make Copy Settings Modal keyboard accessible

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.2.1
         version: 8.2.1
+      jmuxer:
+        specifier: ^2.1.1
+        version: 2.1.1
       lucide-react:
         specifier: ^0.473.0
         version: 0.473.0(react@19.2.7)
@@ -1296,6 +1299,9 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  jmuxer@2.1.1:
+    resolution: {integrity: sha512-3UoON/ghRpXS0xA8mQcXn0aN0Sb1JD3kWfaag4V8P118O1iZOkcLd559QnByyuRPtsP0zn6G+L4H0hZueGbP/g==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3260,6 +3266,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
+
+  jmuxer@2.1.1: {}
 
   js-tokens@4.0.0: {}
 

--- a/frontend/src/components/Cameras/CopySettingsModal.jsx
+++ b/frontend/src/components/Cameras/CopySettingsModal.jsx
@@ -53,8 +53,17 @@ export const CopySettingsModal = ({
                                 {CAMERA_SETTINGS_CATEGORIES.map(cat => (
                                     <div
                                         key={cat.id}
-                                        className={`flex items-center justify-between p-2 rounded-md cursor-pointer transition-colors ${selectedCategories.includes(cat.id) ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400' : 'hover:bg-muted text-muted-foreground'}`}
+                                        role="checkbox"
+                                        aria-checked={selectedCategories.includes(cat.id)}
+                                        tabIndex={0}
+                                        className={`flex items-center justify-between p-2 rounded-md cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${selectedCategories.includes(cat.id) ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400' : 'hover:bg-muted text-muted-foreground'}`}
                                         onClick={() => toggleCategory(cat.id)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                e.preventDefault();
+                                                toggleCategory(cat.id);
+                                            }
+                                        }}
                                     >
                                         <span className="text-sm font-medium">{cat.label}</span>
                                         <div className={`w-4 h-4 rounded border transition-colors flex items-center justify-center ${selectedCategories.includes(cat.id) ? 'bg-blue-500 border-blue-500' : 'border-muted-foreground/30'}`}>
@@ -64,8 +73,8 @@ export const CopySettingsModal = ({
                                 ))}
                             </div>
                             <div className="flex gap-2 mt-2">
-                                <button className="text-[10px] uppercase font-bold text-blue-600 hover:underline" onClick={() => setSelectedCategories(CAMERA_SETTINGS_CATEGORIES.map(c => c.id))}>{t('cameras.select_all', 'Select All')}</button>
-                                <button className="text-[10px] uppercase font-bold text-muted-foreground hover:underline" onClick={() => setSelectedCategories([])}>{t('cameras.clear', 'Clear')}</button>
+                                <button className="text-[10px] uppercase font-bold text-blue-600 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm px-0.5" onClick={() => setSelectedCategories(CAMERA_SETTINGS_CATEGORIES.map(c => c.id))}>{t('cameras.select_all', 'Select All')}</button>
+                                <button className="text-[10px] uppercase font-bold text-muted-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm px-0.5" onClick={() => setSelectedCategories([])}>{t('cameras.clear', 'Clear')}</button>
                             </div>
                         </div>
 
@@ -76,12 +85,25 @@ export const CopySettingsModal = ({
                                 {cameras.filter(c => c.id !== editingId).map(cam => (
                                     <div
                                         key={cam.id}
-                                        className={`flex items-center p-2 rounded-md cursor-pointer transition-colors ${copyTargets.includes(cam.id) ? 'bg-primary/10 text-primary' : 'hover:bg-muted text-muted-foreground'}`}
+                                        role="checkbox"
+                                        aria-checked={copyTargets.includes(cam.id)}
+                                        tabIndex={0}
+                                        className={`flex items-center p-2 rounded-md cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${copyTargets.includes(cam.id) ? 'bg-primary/10 text-primary' : 'hover:bg-muted text-muted-foreground'}`}
                                         onClick={() => {
                                             if (copyTargets.includes(cam.id)) {
                                                 setCopyTargets(copyTargets.filter(id => id !== cam.id));
                                             } else {
                                                 setCopyTargets([...copyTargets, cam.id]);
+                                            }
+                                        }}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                e.preventDefault();
+                                                if (copyTargets.includes(cam.id)) {
+                                                    setCopyTargets(copyTargets.filter(id => id !== cam.id));
+                                                } else {
+                                                    setCopyTargets([...copyTargets, cam.id]);
+                                                }
                                             }
                                         }}
                                     >
@@ -99,8 +121,8 @@ export const CopySettingsModal = ({
                                 )}
                             </div>
                             <div className="flex gap-2 mt-2">
-                                <button className="text-[10px] uppercase font-bold text-blue-600 hover:underline" onClick={() => setCopyTargets(cameras.filter(c => c.id !== editingId).map(c => c.id))}>{t('cameras.select_all', 'Select All')}</button>
-                                <button className="text-[10px] uppercase font-bold text-muted-foreground hover:underline" onClick={() => setCopyTargets([])}>{t('cameras.clear', 'Clear')}</button>
+                                <button className="text-[10px] uppercase font-bold text-blue-600 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm px-0.5" onClick={() => setCopyTargets(cameras.filter(c => c.id !== editingId).map(c => c.id))}>{t('cameras.select_all', 'Select All')}</button>
+                                <button className="text-[10px] uppercase font-bold text-muted-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm px-0.5" onClick={() => setCopyTargets([])}>{t('cameras.clear', 'Clear')}</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Added keyboard navigation support (`tabIndex`, `onKeyDown`), ARIA checkbox roles, and visible focus indicators to the custom selection lists and buttons in the Copy Settings Modal.
🎯 Why: Keyboard users were previously unable to navigate or select which camera settings to copy or which cameras to apply them to, as the `div` list items lacked keyboard event handlers and focus ability.
📸 Before/After: N/A
♿ Accessibility: Critical improvement allowing full keyboard navigation (Tab, Enter/Space) for selection lists and maintaining visible focus states for WCAG compliance.

---
*PR created automatically by Jules for task [9139372737650443923](https://jules.google.com/task/9139372737650443923) started by @spupuz*