### PR TITLE
🎨 Palette: [UX improvement] Add keyboard focus states to timeline overlay buttons

### DIFF
--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -100,7 +100,7 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                         href={`/api/events/${event.id}/download`}
                         download
                         onClick={(e) => e.stopPropagation()}
-                        className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors"
+                        className="p-1 bg-black/50 hover:bg-black/70 text-white rounded backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
                         title={t('common.download', 'Download')}
                         aria-label={t('common.download', 'Download')}
                     >
@@ -114,7 +114,7 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
                                 e.stopPropagation();
                                 onDelete(event.id);
                             }}
-                            className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors"
+                            className="p-1 bg-black/50 hover:bg-red-500/80 text-white rounded backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-1"
                             title={t('common.delete', 'Delete')}
                             aria-label={t('common.delete', 'Delete')}
                         >

--- a/frontend/src/components/Timeline/EventFilters.jsx
+++ b/frontend/src/components/Timeline/EventFilters.jsx
@@ -152,7 +152,7 @@ export const EventFilters = React.memo(({
             {/* Reset Button */}
             <button
                 onClick={onReset}
-                className={`flex items-center space-x-1.5 px-3 py-2 border rounded-xl text-sm transition-all
+                className={`flex items-center space-x-1.5 px-3 py-2 border rounded-xl text-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                 ${selectedDate === new Date().toLocaleDateString('en-CA') && selectedCameraFilter === 'all' && selectedTypeFilter === 'all' && selectedObjectFilter === 'all' && selectedEventTypeFilter === 'all'
                         ? 'bg-primary/10 border-primary/20 text-primary font-medium'
                         : 'bg-card border-border hover:bg-accent text-muted-foreground'
@@ -165,7 +165,7 @@ export const EventFilters = React.memo(({
             {selectedHour !== null && (
                 <button
                     onClick={() => setSelectedHour(null)}
-                    className="px-3 py-2 text-sm bg-red-500/10 text-red-500 border border-red-500/20 rounded-xl hover:bg-red-500/20 transition-colors flex items-center gap-1.5"
+                    className="px-3 py-2 text-sm bg-red-500/10 text-red-500 border border-red-500/20 rounded-xl hover:bg-red-500/20 transition-colors flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                     aria-label={`Clear hour filter for ${selectedHour}:00`}
                 >
                     <span className="font-bold">{selectedHour}:00</span>


### PR DESCRIPTION
💡 What:
Added Tailwind `focus-visible` utility classes to several absolute-positioned or icon-only interactive elements in the Timeline view, specifically the Download and Delete actions on Event Cards, and the Reset and Active Hour filter buttons.

🎯 Why:
These overlay buttons were relying primarily on hover states for interaction cues. When navigating via a keyboard, tabbed focus on these elements was completely invisible, making it very difficult for keyboard users to know which action they were about to trigger.

📸 Before/After:
Before: Tabbing onto the Delete button on an EventCard provided no visual change.
After: Tabbing onto the Delete button applies a red focus ring (`focus-visible:ring-destructive`). Tabbing onto the Download or Filter Reset buttons applies a primary color focus ring (`focus-visible:ring-primary`).

♿ Accessibility:
Ensures keyboard-only and assistive technology users have a clear visual focus indicator when navigating interactive components, directly supporting WCAG success criteria for focus visibility, while explicitly preserving a clean aesthetic for mouse and touch users by utilizing `focus-visible` instead of `focus`.

---
*PR created automatically by Jules for task [9133675066792853919](https://jules.google.com/task/9133675066792853919) started by @spupuz*