### PR TITLE
🎨 Palette: Add keyboard focus indicators to Live View buttons

### DIFF
--- a/frontend/src/pages/LiveView.jsx
+++ b/frontend/src/pages/LiveView.jsx
@@ -222,7 +222,7 @@ const VideoPlayer = ({
             {isFullscreen && (
                 <button
                     onClick={handleExitFullscreen}
-                    className="absolute top-4 right-4 z-[60] p-3 bg-black/70 hover:bg-black/90 text-white rounded-full shadow-2xl backdrop-blur-sm transition-all active:scale-90 border border-white/20"
+                    className="absolute top-4 right-4 z-[60] p-3 bg-black/70 hover:bg-black/90 text-white rounded-full shadow-2xl backdrop-blur-sm transition-all active:scale-90 border border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                     title="Exit Fullscreen" aria-label={t('live.exit_fullscreen', 'Exit Fullscreen')}
                 >
                     <X className="w-6 h-6" />
@@ -305,10 +305,10 @@ const VideoPlayer = ({
             {!showPTZ && (
                 <div className="absolute inset-x-0 bottom-0 p-2 z-40 opacity-0 group-hover:opacity-100 transition-all duration-300 flex justify-center pointer-events-none">
                     <div className="flex items-center gap-0.5 sm:gap-1 bg-black/80 backdrop-blur-xl p-1 rounded-xl border border-white/10 shadow-3xl pointer-events-auto max-w-full overflow-hidden">
-                        <button onClick={() => onFocus(camera.id)} className={`p-1 rounded-md text-white transition-all shrink-0 ${isFocused ? 'bg-primary' : 'hover:bg-white/10'}`} title="Focus" aria-label={t('live.focus', 'Focus')}>
+                        <button onClick={() => onFocus(camera.id)} className={`p-1 rounded-md text-white transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${isFocused ? 'bg-primary' : 'hover:bg-white/10'}`} title="Focus" aria-label={t('live.focus', 'Focus')}>
                             <Square className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                         </button>
-                        <button onClick={handleFullscreen} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Fullscreen" aria-label={t('live.fullscreen', 'Fullscreen')}>
+                        <button onClick={handleFullscreen} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" title="Fullscreen" aria-label={t('live.fullscreen', 'Fullscreen')}>
                             <Maximize2 className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                         </button>
 
@@ -322,16 +322,16 @@ const VideoPlayer = ({
                                     method: 'POST',
                                     headers: { Authorization: `Bearer ${token}` }
                                 }).then(res => { if (res.ok) showToast(`Snapshot saved`, 'success'); });
-                            }} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Take Photo" aria-label={t('live.take_photo', 'Take Photo')}>
+                            }} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" title="Take Photo" aria-label={t('live.take_photo', 'Take Photo')}>
                                 <Camera className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
                         )}
                         {hasPermission(camera, 'can_replay') && (
                             <>
-                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=snapshot`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Gallery" aria-label={t('live.gallery', 'Gallery')}>
+                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=snapshot`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" title="Gallery" aria-label={t('live.gallery', 'Gallery')}>
                                     <ImageIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                                 </button>
-                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=video`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0" title="Videos" aria-label={t('live.videos', 'Videos')}>
+                                <button onClick={() => navigate(`/timeline?camera=${camera.id}&type=video`)} className="p-1 text-white hover:bg-white/10 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" title="Videos" aria-label={t('live.videos', 'Videos')}>
                                     <Play className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                                 </button>
                             </>
@@ -347,7 +347,7 @@ const VideoPlayer = ({
                                     e.stopPropagation();
                                     onToggleRecording(camera);
                                 }}
-                                className={`p-1 rounded-md transition-all shrink-0 ${(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? 'bg-red-600 text-white animate-pulse shadow-[0_0_10px_rgba(220,38,38,0.5)]' : 'text-white hover:bg-red-600/50'}`}
+                                className={`p-1 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? 'bg-red-600 text-white animate-pulse shadow-[0_0_10px_rgba(220,38,38,0.5)]' : 'text-white hover:bg-red-600/50'}`}
                                 title={(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? "Stop Recording" : "Start Continuous Recording"}
                                 aria-label={(camera.recording_mode === 'Always' || camera.recording_mode === 'Continuous') ? t('live.stop_recording', 'Stop Recording') : t('live.start_recording', 'Start Continuous Recording')}
                             >
@@ -361,7 +361,7 @@ const VideoPlayer = ({
                                     e.stopPropagation();
                                     setShowPTZ(!showPTZ);
                                 }}
-                                className={`p-1 rounded-md transition-all shrink-0 ${showPTZ ? 'bg-primary text-white shadow-[0_0_10px_rgba(var(--primary),0.5)]' : 'text-white hover:bg-primary/50'}`}
+                                className={`p-1 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${showPTZ ? 'bg-primary text-white shadow-[0_0_10px_rgba(var(--primary),0.5)]' : 'text-white hover:bg-primary/50'}`}
                                 title={showPTZ ? "Hide PTZ Controls" : "Show PTZ Controls"}
                                 aria-label={showPTZ ? t('live.hide_ptz', 'Hide PTZ Controls') : t('live.show_ptz', 'Show PTZ Controls')}
                             >
@@ -369,7 +369,7 @@ const VideoPlayer = ({
                             </button>
                         )}
                         {user?.role === 'admin' && (
-                            <button onClick={() => navigate(`/cameras?edit=${camera.id}`)} className="p-1 text-primary-foreground bg-primary hover:bg-primary/80 rounded-md transition-all shrink-0" title="Settings" aria-label={t('common.settings', 'Settings')}>
+                            <button onClick={() => navigate(`/cameras?edit=${camera.id}`)} className="p-1 text-primary-foreground bg-primary hover:bg-primary/80 rounded-md transition-all shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" title="Settings" aria-label={t('common.settings', 'Settings')}>
                                 <Settings className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </button>
                         )}
@@ -656,7 +656,7 @@ export const LiveView = () => {
                     </div>
 
                     {focusCameraId && (
-                        <button onClick={() => setFocusCameraId(null)} className="text-sm text-primary hover:underline">
+                        <button onClick={() => setFocusCameraId(null)} className="text-sm text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1">
                             {t('live.show_all', 'Show All')}
                         </button>
                     )}


### PR DESCRIPTION
💡 What: Added `focus-visible` utility classes to the interactive buttons within the `LiveView` component (e.g., Focus, Fullscreen, Take Photo, Gallery, Video, PTZ controls, and Show All buttons).
🎯 Why: These hover-triggered action bar buttons lacked keyboard focus indicators, making the interface difficult to navigate for keyboard users.
📸 Before/After: Before, tabbing through the action bar buttons provided no visual feedback on which button was focused. After, a primary-colored ring appears around the focused button.
♿ Accessibility: Improves keyboard accessibility by ensuring interactive elements have clear focus states that comply with WCAG guidelines.

---
*PR created automatically by Jules for task [2133663020891151280](https://jules.google.com/task/2133663020891151280) started by @spupuz*