### PR TITLE
⚡ Bolt: Use lightweight query for camera import to reduce memory bloat

### DIFF
--- a/backend/routers/cameras.py
+++ b/backend/routers/cameras.py
@@ -785,7 +785,8 @@ async def import_cameras(
         parsed_cameras = []
 
         # Pre-fetch existing hosts to avoid N+1 queries during loop
-        all_cams = crud.get_cameras(db, limit=1000)
+        # ⚡ Bolt: Use lightweight query to avoid memory bloat from eagerly loaded relationships
+        all_cams = crud.get_cameras_lightweight(db, skip=0, limit=1000)
         existing_hosts = {
             extract_host(c.rtsp_url)
             for c in all_cams
@@ -911,7 +912,8 @@ async def import_motioneye_cameras(
 
         # Pre-fetch existing hosts to avoid N+1 queries during loop
         # ⚡ Bolt: Fetch existing cameras once instead of inside the O(N) loop
-        all_cams = crud.get_cameras(db, limit=1000)
+        # ⚡ Bolt: Use lightweight query to avoid memory bloat from eagerly loaded relationships
+        all_cams = crud.get_cameras_lightweight(db, skip=0, limit=1000)
         existing_hosts = {
             extract_host(c.rtsp_url)
             for c in all_cams


### PR DESCRIPTION
💡 What: Replaced `crud.get_cameras` with `crud.get_cameras_lightweight` in `backend/routers/cameras.py` import endpoints (both JSON and Tarball imports).
🎯 Why: To prevent fetching unnecessary relationship data (groups, storage_profiles) when only the `rtsp_url` is needed during camera imports, preventing severe memory bloat and slow N+1 style data handling.
📊 Impact: Reduces memory usage and database load significantly during bulk camera imports.
🔬 Measurement: Observe memory footprint and execution time of the import endpoint with a large number of cameras.

---
*PR created automatically by Jules for task [7934735867611095787](https://jules.google.com/task/7934735867611095787) started by @spupuz*