### PR TITLE
🎨 Palette: Add keyboard focus state to CollapsibleSection

### DIFF
--- a/frontend/src/components/ui/CollapsibleSection.jsx
+++ b/frontend/src/components/ui/CollapsibleSection.jsx
@@ -8,7 +8,7 @@ export const CollapsibleSection = ({ title, description, icon, isOpen, onToggle,
                 onClick={() => onToggle(id)}
                 aria-expanded={isOpen}
                 aria-controls={id ? `${id}-content` : undefined}
-                className={`w-full flex items-center justify-between p-4 sm:p-6 text-left transition-colors duration-200 ${isOpen ? 'bg-muted/30' : 'hover:bg-muted/10'}`}
+                className={`w-full flex items-center justify-between p-4 sm:p-6 text-left transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card ${isOpen ? 'bg-muted/30' : 'hover:bg-muted/10'}`}
             >
                 <div className="flex items-center space-x-4 min-w-0 flex-1 mr-2">
                     {icon && (


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind utility classes to the toggle button inside the reusable `CollapsibleSection` component.
🎯 Why: The custom toggle button lacked visible focus states, making it impossible for keyboard users to see when the structural element had focus, degrading the accessibility of settings pages.
📸 Before/After: Visual outline ring appears around the section header when tabbed to via keyboard.
♿ Accessibility: Improved keyboard navigation support by making focus explicitly visible matching the existing design system standards.

---
*PR created automatically by Jules for task [15272503277503877975](https://jules.google.com/task/15272503277503877975) started by @spupuz*