### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection vulnerability in subprocess calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -398,3 +398,7 @@ def is_safe_path(file_path):
         return False
 ```
 I'll create a plan to fix these two vulnerabilities to prevent path traversal/deletion.
+## 2026-08-19 - Argument Injection via Subprocess
+**Vulnerability:** Filenames starting with a hyphen (e.g., `-vframes`) could be interpreted as command-line flags by `ffprobe` and `ffmpeg` if passed directly.
+**Learning:** Relying on basic checks or attempting to reject hyphenated filenames causes functional regressions by breaking legitimately named files.
+**Prevention:** When passing untrusted paths to subprocess tools, always wrap them in `os.path.abspath()` to ensure they are interpreted strictly as paths.

--- a/backend/fix_thumbnails.py
+++ b/backend/fix_thumbnails.py
@@ -11,9 +11,9 @@ def generate_thumbnail(video_path, thumb_path):
     try:
         os.makedirs(os.path.dirname(thumb_path), exist_ok=True)
         subprocess.run([
-            "ffmpeg", "-y", "-i", video_path, 
+            "ffmpeg", "-y", "-i", os.path.abspath(video_path),
             "-ss", "00:00:00.5", "-vframes", "1", "-vf", "scale=320:-1",
-            thumb_path
+            os.path.abspath(thumb_path)
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
         return True
     except Exception as e:

--- a/backend/migrate_and_sync.py
+++ b/backend/migrate_and_sync.py
@@ -32,7 +32,7 @@ def get_video_duration(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", os.path.abspath(file_path)
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5)
         if result.returncode == 0:
@@ -44,9 +44,9 @@ def get_video_duration(file_path):
 def generate_thumbnail(video_path, thumb_path):
     try:
         subprocess.run([
-            "ffmpeg", "-y", "-i", video_path, 
+            "ffmpeg", "-y", "-i", os.path.abspath(video_path),
             "-ss", "00:00:01", "-vframes", "1", "-vf", "scale=320:-1",
-            thumb_path
+            os.path.abspath(thumb_path)
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return True
     except:

--- a/backend/sync_recordings.py
+++ b/backend/sync_recordings.py
@@ -37,7 +37,7 @@ def get_video_duration(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", os.path.abspath(file_path)
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
         if result.returncode == 0:
@@ -52,9 +52,9 @@ def generate_thumbnail(video_path, thumb_path):
         os.makedirs(os.path.dirname(thumb_path), exist_ok=True)
         # Use simple seek to start
         subprocess.run([
-            "ffmpeg", "-y", "-i", video_path, 
+            "ffmpeg", "-y", "-i", os.path.abspath(video_path),
             "-ss", "00:00:00.5", "-vframes", "1", "-vf", "scale=320:-1",
-            thumb_path
+            os.path.abspath(thumb_path)
         ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=45) # Increased timeout
         return True
     except subprocess.CalledProcessError as e:
@@ -69,7 +69,7 @@ def is_video_valid(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", os.path.abspath(file_path)
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
         if result.returncode != 0:


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix argument injection vulnerability in subprocess calls

🚨 Severity: HIGH
💡 Vulnerability: Command line argument injection where malicious filenames starting with `-` could be interpreted as options by `ffprobe` or `ffmpeg`.
🎯 Impact: An attacker who can influence the filename could pass arbitrary options to `ffprobe`/`ffmpeg`, leading to execution of unintended actions or potential arbitrary command execution (e.g., via `-f`).
🔧 Fix: Wrapped all input and output path parameters with `os.path.abspath()`, ensuring they are treated strictly as paths and not flags.
✅ Verification: Ran `ruff check` on modified files and the full backend `pytest` suite ensuring all tests pass with no regressions.

---
*PR created automatically by Jules for task [10684237268236654064](https://jules.google.com/task/10684237268236654064) started by @spupuz*