### PR TITLE
🎨 Palette: Improve action button hit targets in user list

### DIFF
--- a/frontend/src/pages/Settings/sections/UserManager.jsx
+++ b/frontend/src/pages/Settings/sections/UserManager.jsx
@@ -281,7 +281,7 @@ export const UserManager = ({
                                             {u.id !== currentUser.id && (
                                                 <button
                                                     onClick={() => handleEditClick(u)}
-                                                    className="p-2 hover:bg-muted text-muted-foreground hover:text-foreground rounded-lg transition-colors"
+                                                    className="p-2 hover:bg-muted text-muted-foreground hover:text-foreground rounded-lg transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
                                                     title={t('settings_usermanager.title', 'Edit User')}
                                                     aria-label={t('settings_usermanager.title', 'Edit User')}
                                                 >
@@ -290,7 +290,7 @@ export const UserManager = ({
                                             )}
                                             <button
                                                 onClick={() => openPasswordModal(u)}
-                                                className="p-2 hover:bg-muted text-muted-foreground hover:text-foreground rounded-lg transition-colors"
+                                                className="p-2 hover:bg-muted text-muted-foreground hover:text-foreground rounded-lg transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
                                                 title={t('settings_usermanager.title', 'Change Password')}
                                                 aria-label={t('settings_usermanager.title', 'Change Password')}
                                             >
@@ -324,7 +324,7 @@ export const UserManager = ({
                                                             onCancel: () => setConfirmConfig({ isOpen: false })
                                                         });
                                                     }}
-                                                    className="p-2 hover:bg-red-100 text-red-500 rounded-lg transition-colors"
+                                                    className="p-2 hover:bg-red-100 text-red-500 rounded-lg transition-colors flex items-center justify-center min-h-[44px] min-w-[44px]"
                                                     title={t('settings_usermanager.title', 'Delete User')}
                                                     aria-label={t('settings_usermanager.title', 'Delete User')}
                                                 >


### PR DESCRIPTION
💡 What: Updated the action buttons (Edit, Change Password, Delete User) in the desktop view of the User Manager to use a minimum height and width of 44px, ensuring consistency with the mobile view and aligning with the design system's guidelines.
🎯 Why: To improve the clickability and touch target size for these critical actions. Small icon-only buttons can be difficult to click precisely; enforcing a 44x44px hit area enhances the overall usability of the table.
📸 Before/After: The buttons previously had default padding which resulted in a smaller hit area. They now have an expanded, consistent 44x44px interactive area while keeping the visual icon size the same.
♿ Accessibility: Increased the touch target size of interactive elements to meet WCAG success criterion 2.5.5 (Target Size), making the interface easier to use for everyone, including those with motor impairments or using touch devices.

---
*PR created automatically by Jules for task [14979448982264996511](https://jules.google.com/task/14979448982264996511) started by @spupuz*