### PR TITLE
🎨 Palette: Add aria-label to EventCard

### DIFF
--- a/frontend/src/components/Timeline/EventCard.jsx
+++ b/frontend/src/components/Timeline/EventCard.jsx
@@ -27,6 +27,7 @@ export const EventCard = React.memo(({ event, onClick, camera, isSelected, isMul
             id={`event-${event.id}`}
             role="button"
             tabIndex={0}
+            aria-label={`Event at ${time}`}
             aria-pressed={isSelected}
             className={`flex items-stretch bg-card border rounded-xl overflow-hidden cursor-pointer transition-all hover:shadow-lg group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                 ${isSelected ? 'ring-2 ring-primary border-primary' : 'border-border hover:border-primary/50'}


### PR DESCRIPTION
💡 What: Added an `aria-label` describing the event time to the root `<div role="button">` element in `frontend/src/components/Timeline/EventCard.jsx`.
🎯 Why: Without an `aria-label`, screen readers merely announce "button" when focusing on the EventCard, providing no context. Adding the label ensures the event time is read aloud.
📸 Before/After: No visual changes.
♿ Accessibility: Improves screen reader support for the event cards in the timeline by providing meaningful context to the interactive element.

---
*PR created automatically by Jules for task [13064700853162185310](https://jules.google.com/task/13064700853162185310) started by @spupuz*