### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection prevention rejecting valid files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -398,3 +398,7 @@ def is_safe_path(file_path):
         return False
 ```
 I'll create a plan to fix these two vulnerabilities to prevent path traversal/deletion.
+## 2026-08-21 - Secure Argument Injection Prevention
+**Vulnerability:** Naive argument injection prevention rejected valid filenames starting with a hyphen (e.g., `-video.mp4`), causing a functional denial of service.
+**Learning:** Rejecting valid input based on naively checking for hyphens breaks functionality and is not a robust security control.
+**Prevention:** Secure subprocess calls involving user-controlled filenames by converting the file path to an absolute path (using `os.path.abspath()`) or prefixing with `./`, ensuring it is not interpreted as a command-line flag.

--- a/backend/event_file_service.py
+++ b/backend/event_file_service.py
@@ -217,36 +217,36 @@ def process_webhook_file_event(
 
             # Get Duration using ffprobe
             if local_path and os.path.exists(local_path):
-                # Security: Prevent argument injection
-                if not os.path.basename(local_path).startswith("-"):
-                    try:
-                        cmd = [
-                            "ffprobe",
-                            "-v",
-                            "error",
-                            "-show_entries",
-                            "format=duration",
-                            "-of",
-                            "default=noprint_wrappers=1:nokey=1",
-                            "-i",
-                            local_path,
-                        ]
-                        result = subprocess.run(
-                            cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True,
-                            timeout=10,
-                        )
-                        if result.returncode == 0:
-                            duration_str = result.stdout.strip()
-                            if duration_str and duration_str != "N/A":
-                                duration_sec = float(duration_str)
-                                event_data.timestamp_end = ts + datetime.timedelta(
-                                    seconds=duration_sec
-                                )
-                    except Exception as e:
-                        logger.error(f"[BG-WORK] ffprobe failed: {e}")
+                try:
+                    # Security: Prevent argument injection by using absolute path
+                    safe_path = os.path.abspath(local_path)
+                    cmd = [
+                        "ffprobe",
+                        "-v",
+                        "error",
+                        "-show_entries",
+                        "format=duration",
+                        "-of",
+                        "default=noprint_wrappers=1:nokey=1",
+                        "-i",
+                        safe_path,
+                    ]
+                    result = subprocess.run(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        timeout=10,
+                    )
+                    if result.returncode == 0:
+                        duration_str = result.stdout.strip()
+                        if duration_str and duration_str != "N/A":
+                            duration_sec = float(duration_str)
+                            event_data.timestamp_end = ts + datetime.timedelta(
+                                seconds=duration_sec
+                            )
+                except Exception as e:
+                    logger.error(f"[BG-WORK] ffprobe failed: {e}")
 
             # Generate Thumbnail
             try:
@@ -256,12 +256,14 @@ def process_webhook_file_event(
                     base_db, _ = os.path.splitext(file_path)
                     db_thumb = f"{base_db}.jpg"
 
+                    # Security: Prevent argument injection by using absolute path
+                    safe_path = os.path.abspath(local_path)
                     subprocess.run(
                         [
                             "ffmpeg",
                             "-y",
                             "-i",
-                            local_path,
+                            safe_path,
                             "-ss",
                             "00:00:01",
                             "-vframes",


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Naive argument injection check rejected valid filenames starting with a hyphen.
🎯 Impact: Denies processing (duration extraction and thumbnail generation) for files starting with a hyphen, causing functional denial of service.
🔧 Fix: Replaced the naive check with explicit conversion to an absolute path using `os.path.abspath()` for both ffprobe and ffmpeg subprocess commands.
✅ Verification: Tested changes with pytest and verified with ruff.

---
*PR created automatically by Jules for task [17540634650705099979](https://jules.google.com/task/17540634650705099979) started by @spupuz*