### PR TITLE
🎨 Palette: Add proper label associations for inputs

### DIFF
--- a/frontend/src/components/ApiTokenManager.jsx
+++ b/frontend/src/components/ApiTokenManager.jsx
@@ -177,8 +177,9 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                 <form onSubmit={handleCreateToken} className="bg-muted/30 p-4 rounded-lg border border-border my-4">
                     <div className="flex flex-col sm:flex-row gap-4 items-end">
                         <div className="w-full sm:flex-1">
-                            <label className="text-xs font-medium mb-1 block">{t('timeline.token_name_description', 'Token Name / Description')}</label>
+                            <label htmlFor="tokenName" className="text-xs font-medium mb-1 block cursor-pointer">{t('timeline.token_name_description', 'Token Name / Description')}</label>
                             <input
+                                id="tokenName"
                                 type="text"
                                 className="w-full bg-background border border-input rounded px-3 py-2 text-sm"
                                 placeholder="e.g. Homepage Dashboard"
@@ -188,8 +189,9 @@ export const ApiTokenManager = ({ isOpen, onToggle }) => {
                             />
                         </div>
                         <div className="w-full sm:w-32">
-                            <label className="text-xs font-medium mb-1 block">{t('timeline.expires_in_days', 'Expires in (days)')}</label>
+                            <label htmlFor="tokenExpiresIn" className="text-xs font-medium mb-1 block cursor-pointer">{t('timeline.expires_in_days', 'Expires in (days)')}</label>
                             <input
+                                id="tokenExpiresIn"
                                 type="number"
                                 min="1"
                                 className="w-full bg-background border border-input rounded px-3 py-2 text-sm"

--- a/frontend/src/components/Cameras/AddEditModal/Tabs/AITab.jsx
+++ b/frontend/src/components/Cameras/AddEditModal/Tabs/AITab.jsx
@@ -132,11 +132,12 @@ export const AITab = ({ newCamera, setNewCamera, globalSettings }) => {
 
                         <div className="p-4 bg-primary/5 rounded-xl border border-primary/10 mt-6">
                             <div className="space-y-1">
-                                <label className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider block mb-1">
+                                <label htmlFor="confidenceThreshold" className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider block mb-1 cursor-pointer">
                                     {t('cameras.confidence_threshold', 'Confidence Threshold')}
                                 </label>
                                 <div className="flex items-center gap-3">
                                     <input
+                                        id="confidenceThreshold"
                                         type="range"
                                         min="0.1"
                                         max="0.95"

--- a/frontend/src/components/Cameras/AddEditModal/Tabs/DeviceTab.jsx
+++ b/frontend/src/components/Cameras/AddEditModal/Tabs/DeviceTab.jsx
@@ -15,7 +15,7 @@ export const DeviceTab = ({ newCamera, setNewCamera }) => {
             />
             {newCamera.auto_resolution !== false ? (
                 <div className="space-y-2">
-                    <label className="text-sm font-medium">{t('cameras.video_resolution', 'Video Resolution')}</label>
+                    <span className="text-sm font-medium block">{t('cameras.video_resolution', 'Video Resolution')}</span>
                     <div className="px-3 py-2 bg-muted/50 rounded-lg border border-border text-muted-foreground">
                         {newCamera.resolution_width}x{newCamera.resolution_height} {t('cameras.auto_detected', '(Auto-Detected)')}
                     </div>

--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -67,8 +67,9 @@ export const EventPreview = React.memo(({
                     </div>
                     <div className="flex items-center space-x-2">
                         {/* Mobile Auto-next */}
-                        <label className="flex items-center space-x-1.5 px-2 py-1 bg-muted/50 rounded-lg cursor-pointer transition-all active:scale-95">
+                        <label htmlFor="autoplayNextMobile" className="flex items-center space-x-1.5 px-2 py-1 bg-muted/50 rounded-lg cursor-pointer transition-all active:scale-95">
                             <input
+                                id="autoplayNextMobile"
                                 type="checkbox"
                                 checked={autoplayNext}
                                 onChange={(e) => setAutoplayNext(e.target.checked)}


### PR DESCRIPTION
💡 What: Added missing `htmlFor` and `id` tags to several input/label pairs in the frontend forms (ApiTokenManager, EventPreview, AITab) and corrected a visual-only label in DeviceTab.

🎯 Why: To ensure screen readers can correctly associate inputs with their text descriptions, and to allow users to click the label text to focus the input or toggle the checkbox, improving general usability.

📸 Before/After: Visual appearance remains identical, but labels are now clickable.

♿ Accessibility: WCAG conformance improved by ensuring all forms properly utilize semantic label bindings.

---
*PR created automatically by Jules for task [13027393119548859139](https://jules.google.com/task/13027393119548859139) started by @spupuz*