### PR TITLE
🛡️ Sentinel: [HIGH] Fix command argument injection vulnerability

### DIFF
--- a/backend/event_file_service.py
+++ b/backend/event_file_service.py
@@ -217,36 +217,35 @@ def process_webhook_file_event(
 
             # Get Duration using ffprobe
             if local_path and os.path.exists(local_path):
-                # Security: Prevent argument injection
-                if not os.path.basename(local_path).startswith("-"):
-                    try:
-                        cmd = [
-                            "ffprobe",
-                            "-v",
-                            "error",
-                            "-show_entries",
-                            "format=duration",
-                            "-of",
-                            "default=noprint_wrappers=1:nokey=1",
-                            "-i",
-                            local_path,
-                        ]
-                        result = subprocess.run(
-                            cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True,
-                            timeout=10,
-                        )
-                        if result.returncode == 0:
-                            duration_str = result.stdout.strip()
-                            if duration_str and duration_str != "N/A":
-                                duration_sec = float(duration_str)
-                                event_data.timestamp_end = ts + datetime.timedelta(
-                                    seconds=duration_sec
-                                )
-                    except Exception as e:
-                        logger.error(f"[BG-WORK] ffprobe failed: {e}")
+                # Security: Prevent argument injection by using absolute paths
+                try:
+                    cmd = [
+                        "ffprobe",
+                        "-v",
+                        "error",
+                        "-show_entries",
+                        "format=duration",
+                        "-of",
+                        "default=noprint_wrappers=1:nokey=1",
+                        "-i",
+                        os.path.abspath(local_path),
+                    ]
+                    result = subprocess.run(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        timeout=10,
+                    )
+                    if result.returncode == 0:
+                        duration_str = result.stdout.strip()
+                        if duration_str and duration_str != "N/A":
+                            duration_sec = float(duration_str)
+                            event_data.timestamp_end = ts + datetime.timedelta(
+                                seconds=duration_sec
+                            )
+                except Exception as e:
+                    logger.error(f"[BG-WORK] ffprobe failed: {e}")
 
             # Generate Thumbnail
             try:
@@ -261,14 +260,14 @@ def process_webhook_file_event(
                             "ffmpeg",
                             "-y",
                             "-i",
-                            local_path,
+                            os.path.abspath(local_path),
                             "-ss",
                             "00:00:01",
                             "-vframes",
                             "1",
                             "-vf",
                             "scale=320:-1",
-                            local_thumb,
+                            os.path.abspath(local_thumb),
                         ],
                         check=True,
                         stdout=subprocess.DEVNULL,

--- a/backend/fix_thumbnails.py
+++ b/backend/fix_thumbnails.py
@@ -11,9 +11,9 @@ def generate_thumbnail(video_path, thumb_path):
     try:
         os.makedirs(os.path.dirname(thumb_path), exist_ok=True)
         subprocess.run([
-            "ffmpeg", "-y", "-i", video_path, 
+            "ffmpeg", "-y", "-i", os.path.abspath(video_path),
             "-ss", "00:00:00.5", "-vframes", "1", "-vf", "scale=320:-1",
-            thumb_path
+            os.path.abspath(thumb_path)
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
         return True
     except Exception as e:

--- a/backend/migrate_and_sync.py
+++ b/backend/migrate_and_sync.py
@@ -32,7 +32,7 @@ def get_video_duration(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", os.path.abspath(file_path)
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=5)
         if result.returncode == 0:
@@ -44,9 +44,9 @@ def get_video_duration(file_path):
 def generate_thumbnail(video_path, thumb_path):
     try:
         subprocess.run([
-            "ffmpeg", "-y", "-i", video_path, 
+            "ffmpeg", "-y", "-i", os.path.abspath(video_path),
             "-ss", "00:00:01", "-vframes", "1", "-vf", "scale=320:-1",
-            thumb_path
+            os.path.abspath(thumb_path)
         ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return True
     except:

--- a/backend/sync_recordings.py
+++ b/backend/sync_recordings.py
@@ -37,7 +37,7 @@ def get_video_duration(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", os.path.abspath(file_path)
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
         if result.returncode == 0:
@@ -52,9 +52,9 @@ def generate_thumbnail(video_path, thumb_path):
         os.makedirs(os.path.dirname(thumb_path), exist_ok=True)
         # Use simple seek to start
         subprocess.run([
-            "ffmpeg", "-y", "-i", video_path, 
+            "ffmpeg", "-y", "-i", os.path.abspath(video_path),
             "-ss", "00:00:00.5", "-vframes", "1", "-vf", "scale=320:-1",
-            thumb_path
+            os.path.abspath(thumb_path)
         ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=45) # Increased timeout
         return True
     except subprocess.CalledProcessError as e:
@@ -69,7 +69,7 @@ def is_video_valid(file_path):
     try:
         cmd = [
             "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", "-i", file_path
+            "-of", "default=noprint_wrappers=1:nokey=1", "-i", os.path.abspath(file_path)
         ]
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=10)
         if result.returncode != 0:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When passing filenames to command-line tools like `ffmpeg` or `ffprobe`, if a filename starts with a hyphen `-` (e.g., `-input.mp4`), it can be misinterpreted as an option flag by the command-line tool. This is known as command argument injection.
🎯 Impact: Malicious or improperly constructed filenames could cause the command-line utility to behave unexpectedly (e.g., hanging, crashing, or exposing data via error logs). It can also create operational issues by rejecting valid filenames.
🔧 Fix: Wrapped the dynamically supplied file path variables (`file_path`, `local_path`, `video_path`, `thumb_path`) with `os.path.abspath()` before passing them into the `subprocess.run` list. This guarantees all file paths begin with the root directory indicator (like `/`), neutralizing any potential for the path string to be interpreted as a flag. Furthermore, removed a brittle mitigation in `backend/event_file_service.py` that naively rejected paths beginning with `-`.
✅ Verification: Ran `ruff check` locally on the impacted files and verified standard Python syntax validity. Code changes simply introduce absolute paths to existing sub-process functionality.

---
*PR created automatically by Jules for task [3516231195281013003](https://jules.google.com/task/3516231195281013003) started by @spupuz*