### PR TITLE
🎨 Palette: Add ARIA labels to Sidebar buttons

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -8,6 +8,8 @@ import { useTranslation } from 'react-i18next';
 const SidebarItem = ({ icon: Icon, label, active, onClick }) => (
     <button
         onClick={onClick}
+        title={label}
+        aria-label={label}
         className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg transition-all duration-200 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card
       ${active
                 ? 'bg-primary/10 text-primary'
@@ -89,6 +91,8 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
             <div className="p-4 border-t border-border space-y-2">
                 <button
                     onClick={() => onTabChange('profile')}
+                    title={user?.username || 'Profile'}
+                    aria-label={user?.username || 'Profile'}
                     className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg transition-all duration-200 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card
                     ${activeTab === 'profile'
                             ? 'bg-primary/10 text-primary'
@@ -103,6 +107,8 @@ export const Sidebar = ({ activeTab, onTabChange, theme, toggleTheme, isOpen, on
 
                 <button
                     onClick={toggleTheme}
+                    title={theme === 'dark' ? t('nav.light_mode', 'Light Mode') : t('nav.dark_mode', 'Dark Mode')}
+                    aria-label={theme === 'dark' ? t('nav.light_mode', 'Light Mode') : t('nav.dark_mode', 'Dark Mode')}
                     className="w-full flex items-center space-x-3 px-4 py-3 rounded-lg text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-all duration-200 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-card"
                 >
                     {theme === 'dark' ? (


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to multiple icon-focused buttons in the Sidebar component (`SidebarItem`, profile button, theme toggle).
🎯 Why: To improve accessibility for screen readers and provide native browser tooltips for users, particularly when the sidebar is minimized or when standard labels might be ambiguous.
📸 Before/After: 
Before: Screen readers would simply announce "button", and hovering provided no information for the profile or theme icons.
After: Screen readers will announce the label (e.g., "Profile", "Light Mode"), and hovering will display the same text as a native tooltip.
♿ Accessibility: Improves WCAG compliance by ensuring interactive elements have descriptive names.

---
*PR created automatically by Jules for task [5134482479670004328](https://jules.google.com/task/5134482479670004328) started by @spupuz*