### PR TITLE
⚡ Bolt: [Fix memory bloat and truncation in groups pagination]

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -441,19 +441,16 @@ def update_user_password(db: Session, user_id: int, hashed_password: str):
 
 
 # Groups
-def get_groups(db: Session, skip: int = 0, limit: int = 100):
-    return (
-        db.query(models.CameraGroup)
-        .options(
-            selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
-            selectinload(models.CameraGroup.cameras).selectinload(
-                models.Camera.storage_profile
-            ),
-        )
-        .offset(skip)
-        .limit(limit)
-        .all()
+def get_groups(db: Session, skip: int = 0, limit: int = 100, allowed_group_ids: list[int] = None):
+    query = db.query(models.CameraGroup).options(
+        selectinload(models.CameraGroup.cameras).selectinload(models.Camera.groups),
+        selectinload(models.CameraGroup.cameras).selectinload(
+            models.Camera.storage_profile
+        ),
     )
+    if allowed_group_ids is not None:
+        query = query.filter(models.CameraGroup.id.in_(allowed_group_ids))
+    return query.offset(skip).limit(limit).all()
 
 
 def get_group(db: Session, group_id: int):

--- a/backend/routers/groups.py
+++ b/backend/routers/groups.py
@@ -17,11 +17,12 @@ router = APIRouter(
 @router.get("", response_model=List[Any])
 def read_groups(skip: int = 0, limit: int = 100, db: Session = Depends(database.get_db), auth_info: tuple[models.User, bool] = Depends(auth_service.get_current_user_or_token)):
     user, is_token = auth_info
-    groups = crud.get_groups(db, skip=skip, limit=limit)
     
+    allowed_group_ids = None
     if user.role == "viewer" and user.restrict_camera_access:
         allowed_group_ids = [g.id for g in user.allowed_groups]
-        groups = [g for g in groups if g.id in allowed_group_ids]
+
+    groups = crud.get_groups(db, skip=skip, limit=limit, allowed_group_ids=allowed_group_ids)
 
     if is_token:
         # Return sanitized groups (masking camera details)


### PR DESCRIPTION
💡 What: Pushed RBAC filtering for `get_groups` down to the database layer by accepting `allowed_group_ids` and applying an `IN` clause before the `.offset().limit()` chain.
🎯 Why: Filtering paginated results in Python memory after a database fetch causes implicit data truncation bugs (where a page could return empty even if valid items exist on subsequent pages) and causes O(N) memory bloat.
📊 Impact: Eliminates Python memory overhead for large group fetches and fixes the API truncation bug for restricted viewers.
🔬 Measurement: Verify that `GET /api/v1/groups` correctly returns a full `limit` sized page of authorized groups for restricted viewers, without missing items.

---
*PR created automatically by Jules for task [16357107634350635716](https://jules.google.com/task/16357107634350635716) started by @spupuz*