### PR TITLE
🎨 Palette: Add proper label associations to forms for accessibility

### DIFF
--- a/frontend/src/components/Timeline/EventPreview.jsx
+++ b/frontend/src/components/Timeline/EventPreview.jsx
@@ -78,6 +78,7 @@ export const EventPreview = React.memo(({
                             <span className="text-[10px] font-bold text-foreground/80 uppercase tracking-tighter">{t('timeline.auto_next', 'Auto-next')}</span>
                             {autoplayNext && (
                                 <select
+                                    id="autoplayDirectionMobile"
                                     aria-label={t('timeline.playback_order', 'Playback Order')}
                                     value={autoplayDirection}
                                     onChange={(e) => {
@@ -174,6 +175,7 @@ export const EventPreview = React.memo(({
                         <label htmlFor="autoplayNextDesktop" className="text-xs font-medium cursor-pointer select-none">{t('timeline.auto_next', 'Auto-next')}</label>
                         {autoplayNext && (
                             <select
+                                id="autoplayDirectionDesktop"
                                 aria-label={t('timeline.playback_order', 'Playback Order')}
                                 value={autoplayDirection}
                                 onChange={(e) => setAutoplayDirection(e.target.value)}

--- a/frontend/src/pages/Logs.jsx
+++ b/frontend/src/pages/Logs.jsx
@@ -138,8 +138,9 @@ export const Logs = () => {
             <div className="bg-card border border-border p-3 rounded-lg flex flex-wrap gap-4 items-center shadow-sm">
 
                 <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium">{t('logs.service', 'Service:')}</span>
+                    <label htmlFor="logsService" className="text-sm font-medium">{t('logs.service', 'Service:')}</label>
                     <select
+                        id="logsService"
                         className="bg-background border border-input rounded px-2 py-1.5 text-sm min-w-[140px]"
                         value={service}
                         onChange={(e) => setService(e.target.value)}
@@ -153,7 +154,9 @@ export const Logs = () => {
                 <div className="flex items-center gap-2 flex-grow max-w-sm">
                     <Search className="w-4 h-4 text-muted-foreground" />
                     <input
+                        id="logsSearch"
                         type="text"
+                        aria-label={t('logs.search_placeholder', 'Search logs...')}
                         placeholder={t('logs.search_placeholder', 'Search logs...')}
                         className="bg-background border border-input rounded px-3 py-1.5 text-sm w-full"
                         value={search}
@@ -162,8 +165,9 @@ export const Logs = () => {
                 </div>
 
                 <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium">{t('logs.lines', 'Lines:')}</span>
+                    <label htmlFor="logsLines" className="text-sm font-medium">{t('logs.lines', 'Lines:')}</label>
                     <input
+                        id="logsLines"
                         type="number"
                         className="bg-background border border-input rounded px-2 py-1.5 text-sm w-20"
                         value={lines}
@@ -333,8 +337,9 @@ const LogSettingsModal = ({ isOpen, onClose, token, showToast }) => {
 
                 <div className="space-y-4">
                     <div>
-                        <label className="block text-sm font-medium mb-1">{t('timeline.max_log_size_mb', 'Max Log Size (MB)')}</label>
+                        <label htmlFor="maxLogSize" className="block text-sm font-medium mb-1">{t('timeline.max_log_size_mb', 'Max Log Size (MB)')}</label>
                         <input
+                            id="maxLogSize"
                             type="number"
                             className="w-full bg-background border border-input rounded px-3 py-2"
                             value={settings.log_max_size_mb}
@@ -344,8 +349,9 @@ const LogSettingsModal = ({ isOpen, onClose, token, showToast }) => {
                     </div>
 
                     <div>
-                        <label className="block text-sm font-medium mb-1">{t('timeline.backup_count', 'Backup Count')}</label>
+                        <label htmlFor="backupCount" className="block text-sm font-medium mb-1">{t('timeline.backup_count', 'Backup Count')}</label>
                         <input
+                            id="backupCount"
                             type="number"
                             className="w-full bg-background border border-input rounded px-3 py-2"
                             value={settings.log_backup_count}
@@ -355,8 +361,9 @@ const LogSettingsModal = ({ isOpen, onClose, token, showToast }) => {
                     </div>
 
                     <div>
-                        <label className="block text-sm font-medium mb-1">{t('timeline.check_interval_minutes', 'Check Interval (Minutes)')}</label>
+                        <label htmlFor="checkInterval" className="block text-sm font-medium mb-1">{t('timeline.check_interval_minutes', 'Check Interval (Minutes)')}</label>
                         <input
+                            id="checkInterval"
                             type="number"
                             className="w-full bg-background border border-input rounded px-3 py-2"
                             value={settings.log_rotation_check_minutes}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -367,8 +367,9 @@ export const Profile = () => {
                         </div>
                         <form onSubmit={handlePasswordUpdate} className="space-y-4">
                             <div>
-                                <label className="text-sm font-medium mb-1 block">{t('timeline.current_password', 'Current Password')}</label>
+                                <label htmlFor="oldPassword" className="text-sm font-medium mb-1 block">{t('timeline.current_password', 'Current Password')}</label>
                                 <input
+                                    id="oldPassword"
                                     type="password"
                                     className="w-full bg-background border border-input rounded-lg px-3 py-2 focus:ring-2 focus:ring-primary/20 outline-none transition-all"
                                     required
@@ -377,8 +378,9 @@ export const Profile = () => {
                                 />
                             </div>
                             <div>
-                                <label className="text-sm font-medium mb-1 block">{t('timeline.new_password', 'New Password')}</label>
+                                <label htmlFor="newPassword" className="text-sm font-medium mb-1 block">{t('timeline.new_password', 'New Password')}</label>
                                 <input
+                                    id="newPassword"
                                     type="password"
                                     className="w-full bg-background border border-input rounded-lg px-3 py-2 focus:ring-2 focus:ring-primary/20 outline-none transition-all"
                                     required
@@ -387,8 +389,9 @@ export const Profile = () => {
                                 />
                             </div>
                             <div>
-                                <label className="text-sm font-medium mb-1 block">{t('timeline.confirm_new_password', 'Confirm New Password')}</label>
+                                <label htmlFor="confirmPassword" className="text-sm font-medium mb-1 block">{t('timeline.confirm_new_password', 'Confirm New Password')}</label>
                                 <input
+                                    id="confirmPassword"
                                     type="password"
                                     className="w-full bg-background border border-input rounded-lg px-3 py-2 focus:ring-2 focus:ring-primary/20 outline-none transition-all"
                                     required
@@ -423,8 +426,9 @@ export const Profile = () => {
                         </div>
                         <form onSubmit={disable2FA} className="space-y-4">
                             <div>
-                                <label className="text-sm font-medium mb-1 block">{t('timeline.current_password', 'Current Password')}</label>
+                                <label htmlFor="disable2FAPassword" className="text-sm font-medium mb-1 block">{t('timeline.current_password', 'Current Password')}</label>
                                 <input
+                                    id="disable2FAPassword"
                                     type="password"
                                     className="w-full bg-background border border-input rounded-lg px-3 py-2 focus:ring-2 focus:ring-red-500/20 outline-none transition-all"
                                     required
@@ -475,8 +479,9 @@ export const Profile = () => {
                             </div>
 
                             <div className="pt-2">
-                                <label className="text-sm font-medium mb-1 block">{t('timeline.enter_6_digit_code', 'Enter 6-digit Code')}</label>
+                                <label htmlFor="setup2FACode" className="text-sm font-medium mb-1 block">{t('timeline.enter_6_digit_code', 'Enter 6-digit Code')}</label>
                                 <input
+                                    id="setup2FACode"
                                     type="text"
                                     className="w-full bg-background border border-input rounded-lg px-3 py-2 text-center text-xl tracking-widest font-mono focus:ring-2 focus:ring-primary/20 outline-none transition-all"
                                     required


### PR DESCRIPTION
💡 What: Linked orphaned form labels to their input fields by wrapping spans into proper `<label>` elements and using the `htmlFor` attribute pointing to specific `id` attributes on the input fields. I targeted various forms spanning from the Log Settings and Log Search to the Password modification forms and Two-Factor Authentication setup flows. I also properly identified inputs lacking text labels by adding `aria-label`.

🎯 Why: To meet basic WCAG web accessibility standards. Prior to this, form labels were unassociated (or just plain `<span>` tags), meaning screen readers had poor context of what an input was for, and users could not benefit from the standard UX behavior of clicking a text label to instantly focus its adjacent input field.

📸 Before/After: Visual presentation is identical, but structurally inputs are tied to labels.

♿ Accessibility: Massively improves the experience for screen-reader users parsing forms on the Logs and Profile pages. Adds click-to-focus functionality on labels, expanding the tap target size and aiding motor-impaired users.

---
*PR created automatically by Jules for task [8886142229542713481](https://jules.google.com/task/8886142229542713481) started by @spupuz*