### PR TITLE
🎨 Palette: Add accessible label to new group input

### DIFF
--- a/frontend/src/components/GroupsManager.jsx
+++ b/frontend/src/components/GroupsManager.jsx
@@ -392,7 +392,11 @@ export const GroupsManager = ({ cameras, onUpdate }) => {
                 <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <form onSubmit={handleCreateGroup} className="bg-card p-6 rounded-xl w-full max-w-sm border border-border">
                         <h3 className="text-lg font-bold mb-4">{t('timeline.create_new_group', 'Create New Group')}</h3>
+                        <label htmlFor="newGroupName" className="block text-sm font-medium mb-1 cursor-pointer">
+                            {t('timeline.group_name_label', 'Group Name')}
+                        </label>
                         <input
+                            id="newGroupName"
                             autoFocus
                             className="w-full px-3 py-2 bg-background border border-input rounded-md mb-4"
                             placeholder="Group Name"


### PR DESCRIPTION
💡 What: Added an accessible `<label>` element for the "Group Name" input field in the Create Group modal in `GroupsManager.jsx`.
🎯 Why: Improves form accessibility by explicitly linking the input to a descriptive label, assisting screen readers and allowing users to click the label to focus the input.
📸 Before/After: Visual change is minor (added a small label above the input), but the structural change significantly improves semantics.
♿ Accessibility: Added `id` to the input and a corresponding `<label htmlFor="newGroupName">` to meet WCAG standards.

---
*PR created automatically by Jules for task [3922993784565044196](https://jules.google.com/task/3922993784565044196) started by @spupuz*