### PR TITLE
🛡️ Sentinel: [HIGH] Fix Host Header Validation bypass in OAuth

### DIFF
--- a/backend/routers/oauth.py
+++ b/backend/routers/oauth.py
@@ -54,7 +54,7 @@ async def oauth_login(request: Request, db: Session = Depends(database.get_db)):
     # because SSL-terminating proxies often mask the original protocol.
     host = request.headers.get("host", "")
     import re
-    if not re.match(r"^[0-9\.]+(:\d+)?$", host) and not host.startswith("localhost"):
+    if not re.match(r"^[0-9\.]+(:\d+)?$", host) and not re.match(r"^localhost(:\d+)?$", host):
         if base_url.startswith("http://"):
             base_url = base_url.replace("http://", "https://", 1)
     
@@ -141,7 +141,7 @@ async def oauth_callback(request: Request, db: Session = Depends(database.get_db
     base_url = str(request.base_url)
     host = request.headers.get("host", "")
     import re
-    if not re.match(r"^[0-9\.]+(:\d+)?$", host) and not host.startswith("localhost"):
+    if not re.match(r"^[0-9\.]+(:\d+)?$", host) and not re.match(r"^localhost(:\d+)?$", host):
         if base_url.startswith("http://"):
             base_url = base_url.replace("http://", "https://", 1)
     if base_url.endswith('/'):
@@ -192,7 +192,7 @@ async def oauth_logout(request: Request, db: Session = Depends(database.get_db))
         base_url = str(request.base_url)
         host = request.headers.get("host", "")
         import re
-        if not re.match(r"^[0-9\.]+(:\d+)?$", host) and not host.startswith("localhost"):
+        if not re.match(r"^[0-9\.]+(:\d+)?$", host) and not re.match(r"^localhost(:\d+)?$", host):
             if base_url.startswith("http://"):
                 base_url = base_url.replace("http://", "https://", 1)
         if base_url.endswith('/'):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The host header validation in the OAuth router uses an insecure `startswith("localhost")` check to bypass HTTPS enforcement, allowing attackers to use domains like `localhost.attacker.com` to downgrade OAuth callbacks to HTTP, potentially intercepting tokens.
🎯 Impact: An attacker could trick a user into completing an OAuth flow over an unencrypted connection, intercepting their authorization codes or tokens.
🔧 Fix: Replaced `host.startswith("localhost")` with a strict regex check (`^localhost(:\d+)?$`) to ensure only actual localhost URLs bypass the HTTPS requirement.
✅ Verification: Ensured the linter passes and the test suite is successful.

---
*PR created automatically by Jules for task [14051550133012186741](https://jules.google.com/task/14051550133012186741) started by @spupuz*