### PR TITLE
🎨 Palette: Add `htmlFor` attributes to FederationSettings form labels

### DIFF
--- a/frontend/src/pages/Settings/sections/FederationSettings.jsx
+++ b/frontend/src/pages/Settings/sections/FederationSettings.jsx
@@ -199,8 +199,9 @@ export const FederationSettings = ({ isOpen, onToggle }) => {
                         
                         <div className="grid gap-4 md:grid-cols-2">
                             <div className="space-y-2">
-                                <label className="text-sm font-medium">{t('common.name', 'Name')}</label>
+                                <label htmlFor="node-name" className="text-sm font-medium">{t('common.name', 'Name')}</label>
                                 <input
+                                    id="node-name"
                                     type="text"
                                     required
                                     className="w-full p-2 rounded-md bg-background border border-border focus:ring-2 focus:ring-primary/50 text-sm"
@@ -211,8 +212,9 @@ export const FederationSettings = ({ isOpen, onToggle }) => {
                             </div>
                             
                             <div className="space-y-2">
-                                <label className="text-sm font-medium">{t('federation.url', 'Node URL')}</label>
+                                <label htmlFor="node-url" className="text-sm font-medium">{t('federation.url', 'Node URL')}</label>
                                 <input
+                                    id="node-url"
                                     type="url"
                                     required
                                     className="w-full p-2 rounded-md bg-background border border-border focus:ring-2 focus:ring-primary/50 text-sm"
@@ -224,10 +226,11 @@ export const FederationSettings = ({ isOpen, onToggle }) => {
                         </div>
                         
                         <div className="space-y-2">
-                            <label className="text-sm font-medium flex items-center gap-2">
+                            <label htmlFor="node-token" className="text-sm font-medium flex items-center gap-2">
                                 <Key className="w-4 h-4" /> {t('federation.api_token', 'API Token')}
                             </label>
                             <input
+                                id="node-token"
                                 type="password"
                                 required
                                 className="w-full p-2 rounded-md bg-background border border-border focus:ring-2 focus:ring-primary/50 text-sm"


### PR DESCRIPTION
💡 What: Added `htmlFor` attributes to the form labels and corresponding `id` attributes to the input fields in the Add/Edit Node form of `FederationSettings.jsx`. Also created a journal entry documenting this finding.
🎯 Why: Labels without a `htmlFor` attribute linking to an input `id` fail WCAG accessibility standards. Linking them allows users to click the label to focus the input, improving the click-target size and making the interface more usable, especially for screen readers.
📸 Before/After: Before, clicking the "Name", "Node URL", or "API Token" labels did nothing. After, clicking the labels focuses the respective input fields.
♿ Accessibility: Improves form accessibility by explicitly associating labels with their input controls.

---
*PR created automatically by Jules for task [714799223684190329](https://jules.google.com/task/714799223684190329) started by @spupuz*