### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in federation verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -406,3 +406,7 @@ I'll create a plan to fix these two vulnerabilities to prevent path traversal/de
 **Vulnerability:** Naive argument injection prevention rejected valid filenames starting with a hyphen (e.g., `-video.mp4`), causing a functional denial of service.
 **Learning:** Rejecting valid input based on naively checking for hyphens breaks functionality and is not a robust security control.
 **Prevention:** Secure subprocess calls involving user-controlled filenames by converting the file path to an absolute path (using `os.path.abspath()`) or prefixing with `./`, ensuring it is not interpreted as a command-line flag.
+## 2026-08-25 - Fix SSRF in federation verification
+**Vulnerability:** Federated node verification used `requests.get` without `allow_redirects=False`, allowing SSRF attacks via malicious HTTP redirects that could leak API tokens.
+**Learning:** Using `requests` with untrusted URLs inherently follows redirects by default, silently enabling SSRF bypasses if not explicitly disabled.
+**Prevention:** Always explicitly set `allow_redirects=False` when making outbound HTTP calls to user-configurable URLs or external APIs.

--- a/backend/health_service.py
+++ b/backend/health_service.py
@@ -79,7 +79,7 @@ async def check_federation_health():
                         # Re-use _verify_remote_node logic but suppress exceptions
                         import requests
                         base_url = node.url.rstrip("/")
-                        resp = requests.get(f"{base_url}/api/auth/me", headers={"X-API-Key": node.api_token}, timeout=5)
+                        resp = requests.get(f"{base_url}/api/auth/me", headers={"X-API-Key": node.api_token}, timeout=5, allow_redirects=False)
                         if resp.status_code == 200:
                             is_online = True
                     except Exception:

--- a/backend/routers/federation.py
+++ b/backend/routers/federation.py
@@ -19,7 +19,7 @@ router = APIRouter(
 def _verify_remote_node(url: str, token: str):
     base_url = url.rstrip("/")
     try:
-        resp = requests.get(f"{base_url}/api/auth/me", headers={"X-API-Key": token}, timeout=5)
+        resp = requests.get(f"{base_url}/api/auth/me", headers={"X-API-Key": token}, timeout=5, allow_redirects=False)
         if resp.status_code in [401, 403]:
             raise HTTPException(status_code=400, detail="Invalid API token for the remote node.")
         elif resp.status_code != 200:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Federated node verification uses `requests.get` without `allow_redirects=False`, allowing an attacker to bypass basic SSRF protections by redirecting the outbound request to an internal service and potentially leaking the API key.
🎯 Impact: Attackers could scan internal networks or leak the master node's API token to arbitrary internal services.
🔧 Fix: Explicitly added `allow_redirects=False` to the `requests.get` calls in both the synchronous endpoint and background health task.
✅ Verification: Ran backend tests and verified that the SSRF protection now blocks redirects for federated node verification.

---
*PR created automatically by Jules for task [15091301530993216713](https://jules.google.com/task/15091301530993216713) started by @spupuz*