### PR TITLE
🎨 Palette: Add ARIA label to Revoke Device button

### DIFF
--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -737,7 +737,8 @@ export const Profile = () => {
                                                         <button
                                                             onClick={() => handleRevokeDevice(device.id)}
                                                             className="p-2 text-muted-foreground hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-full transition-colors"
-                                                            title="Revoke Device"
+                                                            title={t('profile.revoke_device', 'Revoke Device')}
+                                                            aria-label={t('profile.revoke_device', 'Revoke Device')}
                                                         >
                                                             <Trash2 className="w-4 h-4" />
                                                         </button>


### PR DESCRIPTION
💡 What: Added an `aria-label` and localized the `title` attribute to the icon-only "Revoke Device" button in the Profile page.
🎯 Why: Icon-only buttons without `aria-label` attributes are inaccessible to screen readers. This improves accessibility. Localizing the `title` attribute ensures consistency.
📸 Before/After: N/A
♿ Accessibility: Improved keyboard/screen-reader accessibility for device revocation.

---
*PR created automatically by Jules for task [18096560860024890046](https://jules.google.com/task/18096560860024890046) started by @spupuz*